### PR TITLE
Update libglnx subtree to 2024-04-20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "libglnx"]
-	path = subprojects/libglnx
-	url = https://gitlab.gnome.org/GNOME/libglnx.git
 [submodule "bubblewrap"]
 	path = subprojects/bubblewrap
 	url = https://github.com/containers/bubblewrap.git

--- a/glnx-backports.h
+++ b/glnx-backports.h
@@ -80,6 +80,10 @@ gboolean              glnx_set_object  (GObject **object_ptr,
 #define G_OPTION_FLAG_NONE ((GOptionFlags) 0)
 #endif
 
+#ifndef G_PID_FORMAT  /* added in 2.50 */
+#define G_PID_FORMAT "i"
+#endif
+
 #if !GLIB_CHECK_VERSION(2, 60, 0)
 #define g_strv_equal _glnx_strv_equal
 gboolean _glnx_strv_equal (const gchar * const *strv1,

--- a/glnx-backports.h
+++ b/glnx-backports.h
@@ -125,16 +125,22 @@ _glnx_memdup2 (gconstpointer mem,
   (((a) > (b) ? (a) - (b) : (b) - (a)) < (epsilon))
 #endif
 
-#if !GLIB_CHECK_VERSION(2, 70, 0)
-#define g_steal_fd _glnx_steal_fd
 static inline int
 _glnx_steal_fd (int *fdp)
 {
+#if GLIB_CHECK_VERSION(2, 70, 0)
+  /* Allow it to be used without deprecation warnings, even if the target
+   * GLib version is older */
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  return g_steal_fd (fdp);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#else
   int fd = *fdp;
   *fdp = -1;
   return fd;
-}
 #endif
+}
+#define g_steal_fd _glnx_steal_fd
 
 #if !GLIB_CHECK_VERSION(2, 74, 0)
 #define G_APPLICATION_DEFAULT_FLAGS ((GApplicationFlags) 0)

--- a/meson.build
+++ b/meson.build
@@ -40,7 +40,7 @@ foreach check_function : check_functions
     #include <linux/random.h>
     #include <sys/mman.h>
 
-    int func (void) {
+    void func (void) {
       (void) ''' + check_function + ''';
     }
     ''',

--- a/subprojects/libglnx/.gitignore
+++ b/subprojects/libglnx/.gitignore
@@ -1,0 +1,21 @@
+# Copyright 2015 Colin Walters
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# A path ostree writes to work around automake bug with
+# subdir-objects
+Makefile-libglnx.am.inc
+
+libglnx-config.h
+
+# Some standard bits
+.deps
+.libs
+.dirstamp
+*.typelib
+*.la
+*.lo
+*.o
+*.pyc
+*.stamp
+*~
+

--- a/subprojects/libglnx/.gitlab-ci.yml
+++ b/subprojects/libglnx/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+# Copyright 2019 Endless OS Foundation LLC
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+image: registry.fedoraproject.org/fedora:30
+
+stages:
+  - build
+
+before_script:
+  - dnf install -y gcc git meson ninja-build "pkgconfig(gio-2.0)" "pkgconfig(gio-unix-2.0)" "pkgconfig(glib-2.0)" xz
+
+build:
+  stage: build
+  script:
+    - meson _build .
+    - ninja -C _build
+    - meson test -C _build
+    # Run it again! This previously did not work.
+    - meson test -C _build
+    # Ensure that we can build as a subproject
+    - rm -fr _build/meson-dist
+    - meson dist -C _build
+    - mkdir -p tests/use-as-subproject/subprojects/libglnx
+    - tar --strip-components=1 -C tests/use-as-subproject/subprojects/libglnx -xf _build/meson-dist/*.tar.xz
+    - meson tests/use-as-subproject/_build tests/use-as-subproject
+    - ninja -C tests/use-as-subproject/_build
+    - meson test -C tests/use-as-subproject/_build
+  artifacts:
+    when: on_failure
+    name: "libglnx-${CI_COMMIT_REF_NAME}-${CI_JOB_NAME}"
+    paths:
+      - "${CI_PROJECT_DIR}/_build/meson-logs"
+
+reuse:
+  stage: build
+  image:
+    name: fsfe/reuse:latest
+    entrypoint: [""]
+  before_script: []
+  script:
+    - reuse lint

--- a/subprojects/libglnx/COPYING
+++ b/subprojects/libglnx/COPYING
@@ -1,0 +1,3 @@
+This project's licensing is REUSE-compliant <https://reuse.software/>.
+See individual files for full details of copyright and licensing,
+and see LICENSES/*.txt for the license text.

--- a/subprojects/libglnx/LICENSES/LGPL-2.0-or-later.txt
+++ b/subprojects/libglnx/LICENSES/LGPL-2.0-or-later.txt
@@ -1,0 +1,174 @@
+GNU LIBRARY GENERAL PUBLIC LICENSE
+
+Version 2, June 1991
+
+Copyright (C) 1991 Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Library General Public License, applies to some specially designated Free Software Foundation software, and to any other libraries whose authors decide to use it. You can use it for your libraries, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs; and that you know you can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny you these rights or to ask you to surrender the rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library, or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link a program with the library, you must provide complete object files to the recipients so that they can relink them with the library, after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+Our method of protecting your rights has two steps: (1) copyright the library, and (2) offer you this license which gives you legal permission to copy, distribute and/or modify the library.
+
+Also, for each distributor's protection, we want to make certain that everyone understands that there is no warranty for this free library. If the library is modified by someone else and passed on, we want its recipients to know that what they have is not the original version, so that any problems introduced by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish to avoid the danger that companies distributing free software will individually obtain patent licenses, thus in effect transforming the program into proprietary software. To prevent this, we have made it clear that any patent must be licensed for everyone's free use or not licensed at all.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License, which was designed for utility programs. This license, the GNU Library General Public License, applies to certain designated libraries. This license is quite different from the ordinary one; be sure to read it in full, and don't assume that anything in it is the same as in the ordinary license.
+
+The reason we have a separate public license for some libraries is that they blur the distinction we usually make between modifying or adding to a program and simply using it. Linking a program with a library, without changing the library, is in some sense simply using the library, and is analogous to running a utility program or application program. However, in a textual and legal sense, the linked executable is a combined work, a derivative of the original library, and the ordinary General Public License treats it as such.
+
+Because of this blurred distinction, using the ordinary General Public License for libraries did not effectively promote software sharing, because most developers did not use the libraries. We concluded that weaker conditions might promote sharing better.
+
+However, unrestricted linking of non-free programs would deprive the users of those programs of all benefit from the free status of the libraries themselves. This Library General Public License is intended to permit developers of non-free programs to use free libraries, while preserving your freedom as a user of such programs to change the free libraries that are incorporated in them. (We have not seen how to achieve this as regards changes in header files, but we have achieved it as regards changes in the actual functions of the Library.) The hope is that this will lead to faster development of free libraries.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, while the latter only works together with the library.
+
+Note that it is possible for a library to be covered by the ordinary General Public License rather than by this special one.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Library General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also compile or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     c) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     d) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the source code distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties to this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Library General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Library General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Library General Public License for more details.
+
+     You should have received a copy of the GNU Library General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+
+That's all there is to it!

--- a/subprojects/libglnx/LICENSES/LGPL-2.1-or-later.txt
+++ b/subprojects/libglnx/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/subprojects/libglnx/LICENSES/LicenseRef-old-glib-tests.txt
+++ b/subprojects/libglnx/LICENSES/LicenseRef-old-glib-tests.txt
@@ -1,0 +1,16 @@
+This work is provided "as is"; redistribution and modification
+in whole or in part, in any medium, physical or electronic is
+permitted without restriction.
+
+This work is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+In no event shall the authors or contributors be liable for any
+direct, indirect, incidental, special, exemplary, or consequential
+damages (including, but not limited to, procurement of substitute
+goods or services; loss of use, data, or profits; or business
+interruption) however caused and on any theory of liability, whether
+in contract, strict liability, or tort (including negligence or
+otherwise) arising in any way out of the use of this software, even
+if advised of the possibility of such damage.

--- a/subprojects/libglnx/Makefile-libglnx.am
+++ b/subprojects/libglnx/Makefile-libglnx.am
@@ -1,0 +1,90 @@
+# Copyright (C) 2015 Colin Walters <walters@verbum.org>
+# SPDX-License-Identifier: LGPL-2.0-or-later
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+
+EXTRA_DIST += \
+	$(libglnx_srcpath)/README.md \
+	$(libglnx_srcpath)/COPYING \
+	$(libglnx_srcpath)/LICENSES/LGPL-2.0-or-later.txt \
+	$(libglnx_srcpath)/LICENSES/LGPL-2.1-or-later.txt \
+	$(libglnx_srcpath)/libglnx.m4 \
+	$(NULL)
+
+BUILT_SOURCES += $(top_builddir)/libglnx-config.h
+CLEANFILES += $(top_builddir)/libglnx-config.h
+$(top_builddir)/libglnx-config.h: Makefile.am
+	echo '#include "config.h"' > $@
+
+libglnx_la_SOURCES = \
+	$(libglnx_srcpath)/glnx-macros.h \
+	$(libglnx_srcpath)/glnx-backport-autocleanups.h \
+	$(libglnx_srcpath)/glnx-backport-autoptr.h \
+	$(libglnx_srcpath)/glnx-backport-testutils.h \
+	$(libglnx_srcpath)/glnx-backport-testutils.c \
+	$(libglnx_srcpath)/glnx-backports.h \
+	$(libglnx_srcpath)/glnx-backports.c \
+	$(libglnx_srcpath)/glnx-local-alloc.h \
+	$(libglnx_srcpath)/glnx-local-alloc.c \
+	$(libglnx_srcpath)/glnx-errors.h \
+	$(libglnx_srcpath)/glnx-errors.c \
+	$(libglnx_srcpath)/glnx-console.h \
+	$(libglnx_srcpath)/glnx-console.c \
+	$(libglnx_srcpath)/glnx-dirfd.h \
+	$(libglnx_srcpath)/glnx-dirfd.c \
+	$(libglnx_srcpath)/glnx-fdio.h \
+	$(libglnx_srcpath)/glnx-fdio.c \
+	$(libglnx_srcpath)/glnx-lockfile.h \
+	$(libglnx_srcpath)/glnx-lockfile.c \
+	$(libglnx_srcpath)/glnx-missing-syscall.h \
+	$(libglnx_srcpath)/glnx-missing.h \
+	$(libglnx_srcpath)/glnx-xattrs.h \
+	$(libglnx_srcpath)/glnx-xattrs.c \
+	$(libglnx_srcpath)/glnx-shutil.h \
+	$(libglnx_srcpath)/glnx-shutil.c \
+	$(libglnx_srcpath)/libglnx.h \
+	$(libglnx_srcpath)/tests/libglnx-testlib.h \
+	$(NULL)
+
+libglnx_la_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags) -I$(builddir)
+libglnx_la_LDFLAGS = -avoid-version -Bsymbolic-functions -export-symbols-regex "^glnx_" -no-undefined -export-dynamic 
+libglnx_la_LIBADD = $(libglnx_libs)
+
+libglnx_tests = test-libglnx-xattrs test-libglnx-fdio test-libglnx-errors test-libglnx-macros test-libglnx-shutil
+TESTS += $(libglnx_tests)
+
+libglnx_testlib_sources = $(libglnx_srcpath)/tests/libglnx-testlib.c
+
+check_PROGRAMS += $(libglnx_tests)
+test_libglnx_xattrs_SOURCES = $(libglnx_testlib_sources) $(libglnx_srcpath)/tests/test-libglnx-xattrs.c
+test_libglnx_xattrs_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags)
+test_libglnx_xattrs_LDADD = $(libglnx_libs) libglnx.la
+
+test_libglnx_fdio_SOURCES = $(libglnx_testlib_sources) $(libglnx_srcpath)/tests/test-libglnx-fdio.c
+test_libglnx_fdio_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags)
+test_libglnx_fdio_LDADD = $(libglnx_libs) libglnx.la
+
+test_libglnx_errors_SOURCES = $(libglnx_testlib_sources) $(libglnx_srcpath)/tests/test-libglnx-errors.c
+test_libglnx_errors_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags)
+test_libglnx_errors_LDADD = $(libglnx_libs) libglnx.la
+
+test_libglnx_macros_SOURCES = $(libglnx_testlib_sources) $(libglnx_srcpath)/tests/test-libglnx-macros.c
+test_libglnx_macros_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags)
+test_libglnx_macros_LDADD = $(libglnx_libs) libglnx.la
+
+test_libglnx_shutil_SOURCES = $(libglnx_testlib_sources) $(libglnx_srcpath)/tests/test-libglnx-shutil.c
+test_libglnx_shutil_CFLAGS = $(AM_CFLAGS) $(libglnx_cflags)
+test_libglnx_shutil_LDADD = $(libglnx_libs) libglnx.la

--- a/subprojects/libglnx/README.md
+++ b/subprojects/libglnx/README.md
@@ -1,0 +1,82 @@
+libglnx is the successor to [libgsystem](https://gitlab.gnome.org/Archive/libgsystem).
+
+It is for modules which depend on both GLib and Linux, intended to be
+used as a git submodule.
+
+Features:
+
+ - File APIs which use `openat()` like APIs, but also take a `GCancellable`
+   to support dynamic cancellation
+ - APIs also have a `GError` parameter
+ - High level "shutil", somewhat inspired by Python's
+ - A "console" API for tty output
+ - A backport of the GLib cleanup macros for projects which can't yet take
+   a dependency on 2.40.
+
+Why?
+----
+
+There are multiple projects which have a hard dependency on Linux and
+GLib, such as NetworkManager, ostree, flatpak, etc.  It makes sense
+for them to be able to share Linux-specific APIs.
+
+This module also contains some code taken from systemd, which has very
+high quality LGPLv2+ shared library code, but most of the internal
+shared library is private, and not namespaced.
+
+One could also compare this project to gnulib; the salient differences
+there are that at least some of this module is eventually destined for
+inclusion in GLib.
+
+Adding this to your project
+---------------------------
+
+## Meson
+
+First, set up a Git submodule:
+
+```
+git submodule add https://gitlab.gnome.org/GNOME/libglnx subprojects/libglnx
+```
+
+Or a Git [subtree](https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt):
+
+```
+git remote add libglnx https://gitlab.gnome.org/GNOME/libglnx.git
+git fetch libglnx
+git subtree add -P subprojects/libglnx libglnx/master
+```
+
+Then, in your top-level `meson.build`:
+
+```
+libglnx_dep = subproject('libglnx').get_variable('libglnx_dep')
+# now use libglnx_dep in your dependencies
+```
+
+Porting from libgsystem
+-----------------------
+
+For all of the filesystem access code, libglnx exposes only
+fd-relative API, not `GFile*`.  It does use `GCancellable` where
+applicable.
+
+For local allocation macros, you should start using the `g_auto`
+macros from GLib.  A backport is included in libglnx.  There are a few
+APIs not defined in GLib yet, such as `glnx_autofd`.
+
+`gs_transfer_out_value` is replaced by `g_steal_pointer`.
+
+Contributing
+------------
+
+Development happens in GNOME Gitlab: https://gitlab.gnome.org/GNOME/libglnx
+
+(If you're seeing this on the Github mirror, we used to do development
+ on Github but that was before GNOME deployed Gitlab.)
+
+<!--
+Copyright 2015-2018 Colin Walters
+Copyright 2019 Endless OS Foundation LLC
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->

--- a/subprojects/libglnx/glnx-backport-autocleanups.h
+++ b/subprojects/libglnx/glnx-backport-autocleanups.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 Canonical Limited
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the licence, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Ryan Lortie <desrt@desrt.ca>
+ */
+
+#pragma once
+
+#include <glnx-backport-autoptr.h>
+
+#if !GLIB_CHECK_VERSION(2, 43, 4)
+
+static inline void
+g_autoptr_cleanup_generic_gfree (void *p)
+{ 
+  void **pp = (void**)p;
+  if (*pp)
+    g_free (*pp);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncQueue, g_async_queue_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GBookmarkFile, g_bookmark_file_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GBytes, g_bytes_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GChecksum, g_checksum_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDateTime, g_date_time_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDir, g_dir_close)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GError, g_error_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GHashTable, g_hash_table_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GHmac, g_hmac_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GIOChannel, g_io_channel_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GKeyFile, g_key_file_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GList, g_list_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GArray, g_array_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GPtrArray, g_ptr_array_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMainContext, g_main_context_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMainLoop, g_main_loop_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSource, g_source_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMappedFile, g_mapped_file_unref)
+#if GLIB_CHECK_VERSION(2, 36, 0)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMarkupParseContext, g_markup_parse_context_unref)
+#endif
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(gchar, g_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GNode, g_node_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOptionContext, g_option_context_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOptionGroup, g_option_group_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GPatternSpec, g_pattern_spec_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GQueue, g_queue_free)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GQueue, g_queue_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRand, g_rand_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GRegex, g_regex_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMatchInfo, g_match_info_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GScanner, g_scanner_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSequence, g_sequence_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSList, g_slist_free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GStringChunk, g_string_chunk_free)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(GStrv, g_strfreev, NULL)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GThread, g_thread_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GMutex, g_mutex_clear)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GCond, g_cond_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTimer, g_timer_destroy)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTimeZone, g_time_zone_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTree, g_tree_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariant, g_variant_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantBuilder, g_variant_builder_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantBuilder, g_variant_builder_clear)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantIter, g_variant_iter_free)
+#if GLIB_CHECK_VERSION(2, 40, 0)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantDict, g_variant_dict_unref)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantDict, g_variant_dict_clear)
+#endif
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantType, g_variant_type_free)
+#if GLIB_CHECK_VERSION(2, 40, 0)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocess, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocessLauncher, g_object_unref)
+#endif
+
+/* Add GObject-based types as needed. */
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncResult, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GCancellable, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GConverter, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GConverterOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDataInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFile, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileEnumerator, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileIOStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileInfo, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileMonitor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GFileOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMemoryInputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMemoryOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GMount, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GOutputStream, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSocket, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSocketAddress, g_object_unref)
+#if GLIB_CHECK_VERSION(2, 36, 0)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTask, g_object_unref)
+#endif
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsCertificate, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsDatabase, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GTlsInteraction, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDBusConnection, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GDBusMessage, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVolumeMonitor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GZlibCompressor, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GZlibDecompressor, g_object_unref)
+
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 45, 8)
+
+static inline void
+g_autoptr_cleanup_gstring_free (GString *string)
+{
+  if (string)
+    g_string_free (string, TRUE);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GString, g_autoptr_cleanup_gstring_free)
+
+#endif

--- a/subprojects/libglnx/glnx-backport-autoptr.h
+++ b/subprojects/libglnx/glnx-backport-autoptr.h
@@ -1,0 +1,134 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ * 
+ * GLIB - Library of useful routines for C programming
+ * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#if !GLIB_CHECK_VERSION(2, 43, 4)
+
+#define _GLIB_AUTOPTR_FUNC_NAME(TypeName) glib_autoptr_cleanup_##TypeName
+#define _GLIB_AUTOPTR_TYPENAME(TypeName)  TypeName##_autoptr
+#define _GLIB_AUTO_FUNC_NAME(TypeName)    glib_auto_cleanup_##TypeName
+#define _GLIB_CLEANUP(func)               __attribute__((cleanup(func)))
+#define _GLIB_DEFINE_AUTOPTR_CHAINUP(ModuleObjName, ParentName) \
+  typedef ModuleObjName *_GLIB_AUTOPTR_TYPENAME(ModuleObjName);                                          \
+  static inline void _GLIB_AUTOPTR_FUNC_NAME(ModuleObjName) (ModuleObjName **_ptr) {                     \
+    _GLIB_AUTOPTR_FUNC_NAME(ParentName) ((ParentName **) _ptr); }                                        \
+
+
+/* these macros are API */
+#define G_DEFINE_AUTOPTR_CLEANUP_FUNC(TypeName, func) \
+  typedef TypeName *_GLIB_AUTOPTR_TYPENAME(TypeName);                                                           \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTOPTR_FUNC_NAME(TypeName) (TypeName **_ptr) { if (*_ptr) (func) (*_ptr); }         \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(TypeName, func) \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTO_FUNC_NAME(TypeName) (TypeName *_ptr) { (func) (_ptr); }                         \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define G_DEFINE_AUTO_CLEANUP_FREE_FUNC(TypeName, func, none) \
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS                                                                              \
+  static inline void _GLIB_AUTO_FUNC_NAME(TypeName) (TypeName *_ptr) { if (*_ptr != none) (func) (*_ptr); }     \
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#define g_autoptr(TypeName) _GLIB_CLEANUP(_GLIB_AUTOPTR_FUNC_NAME(TypeName)) _GLIB_AUTOPTR_TYPENAME(TypeName)
+#define g_auto(TypeName) _GLIB_CLEANUP(_GLIB_AUTO_FUNC_NAME(TypeName)) TypeName
+#define g_autofree _GLIB_CLEANUP(g_autoptr_cleanup_generic_gfree)
+
+/**
+ * g_steal_pointer:
+ * @pp: a pointer to a pointer
+ *
+ * Sets @pp to %NULL, returning the value that was there before.
+ *
+ * Conceptually, this transfers the ownership of the pointer from the
+ * referenced variable to the "caller" of the macro (ie: "steals" the
+ * reference).
+ *
+ * The return value will be properly typed, according to the type of
+ * @pp.
+ *
+ * This can be very useful when combined with g_autoptr() to prevent the
+ * return value of a function from being automatically freed.  Consider
+ * the following example (which only works on GCC and clang):
+ *
+ * |[
+ * GObject *
+ * create_object (void)
+ * {
+ *   g_autoptr(GObject) obj = g_object_new (G_TYPE_OBJECT, NULL);
+ *
+ *   if (early_error_case)
+ *     return NULL;
+ *
+ *   return g_steal_pointer (&obj);
+ * }
+ * ]|
+ *
+ * It can also be used in similar ways for 'out' parameters and is
+ * particularly useful for dealing with optional out parameters:
+ *
+ * |[
+ * gboolean
+ * get_object (GObject **obj_out)
+ * {
+ *   g_autoptr(GObject) obj = g_object_new (G_TYPE_OBJECT, NULL);
+ *
+ *   if (early_error_case)
+ *     return FALSE;
+ *
+ *   if (obj_out)
+ *     *obj_out = g_steal_pointer (&obj);
+ *
+ *   return TRUE;
+ * }
+ * ]|
+ *
+ * In the above example, the object will be automatically freed in the
+ * early error case and also in the case that %NULL was given for
+ * @obj_out.
+ *
+ * Since: 2.44
+ */
+static inline gpointer
+(g_steal_pointer) (gpointer pp)
+{
+  gpointer *ptr = (gpointer *) pp;
+  gpointer ref;
+
+  ref = *ptr;
+  *ptr = NULL;
+
+  return ref;
+}
+
+/* type safety */
+#define g_steal_pointer(pp) \
+  (0 ? (*(pp)) : (g_steal_pointer) (pp))
+
+#endif /* !GLIB_CHECK_VERSION(2, 43, 3) */
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-backport-testutils.c
+++ b/subprojects/libglnx/glnx-backport-testutils.c
@@ -1,0 +1,162 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright 2015 Colin Walters
+ * Copyright 2020 Niels De Graef
+ * Copyright 2021-2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <string.h>
+#include <unistd.h>
+
+#include <glib/gprintf.h>
+
+#include "glnx-backport-autocleanups.h"
+#include "glnx-backport-autoptr.h"
+#include "glnx-backport-testutils.h"
+#include "glnx-backports.h"
+
+#include <sys/prctl.h>
+#include <sys/resource.h>
+
+#if !GLIB_CHECK_VERSION (2, 68, 0)
+/* Backport of g_assertion_message_cmpstrv() */
+void
+_glnx_assertion_message_cmpstrv (const char         *domain,
+                                 const char         *file,
+                                 int                 line,
+                                 const char         *func,
+                                 const char         *expr,
+                                 const char * const *arg1,
+                                 const char * const *arg2,
+                                 gsize               first_wrong_idx)
+{
+  const char *s1 = arg1[first_wrong_idx], *s2 = arg2[first_wrong_idx];
+  char *a1, *a2, *s, *t1 = NULL, *t2 = NULL;
+
+  a1 = g_strconcat ("\"", t1 = g_strescape (s1, NULL), "\"", NULL);
+  a2 = g_strconcat ("\"", t2 = g_strescape (s2, NULL), "\"", NULL);
+  g_free (t1);
+  g_free (t2);
+  s = g_strdup_printf ("assertion failed (%s): first differing element at index %" G_GSIZE_FORMAT ": %s does not equal %s",
+                       expr, first_wrong_idx, a1, a2);
+  g_free (a1);
+  g_free (a2);
+  g_assertion_message (domain, file, line, func, s);
+  g_free (s);
+}
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 70, 0)
+/*
+ * Same as g_test_message(), but split messages with newlines into
+ * multiple separate messages to avoid corrupting stdout, even in older
+ * GLib versions that didn't do this
+ */
+void
+_glnx_test_message_safe (const char *format,
+                         ...)
+{
+  g_autofree char *message = NULL;
+  va_list ap;
+  char *line;
+  char *saveptr = NULL;
+
+  va_start (ap, format);
+  g_vasprintf (&message, format, ap);
+  va_end (ap);
+
+  for (line = strtok_r (message, "\n", &saveptr);
+       line != NULL;
+       line = strtok_r (NULL, "\n", &saveptr))
+    (g_test_message) ("%s", line);
+}
+
+/* Backport of g_test_fail_printf() */
+void
+_glnx_test_fail_printf (const char *format,
+                        ...)
+{
+  g_autofree char *message = NULL;
+  va_list ap;
+
+  va_start (ap, format);
+  g_vasprintf (&message, format, ap);
+  va_end (ap);
+
+  /* This is the closest we can do in older GLib */
+  g_test_message ("Bail out! %s", message);
+  g_test_fail ();
+}
+
+/* Backport of g_test_skip_printf() */
+void
+_glnx_test_skip_printf (const char *format,
+                        ...)
+{
+  g_autofree char *message = NULL;
+  va_list ap;
+
+  va_start (ap, format);
+  g_vasprintf (&message, format, ap);
+  va_end (ap);
+
+  g_test_skip (message);
+}
+
+/* Backport of g_test_incomplete_printf() */
+void
+_glnx_test_incomplete_printf (const char *format,
+                              ...)
+{
+  g_autofree char *message = NULL;
+  va_list ap;
+
+  va_start (ap, format);
+  g_vasprintf (&message, format, ap);
+  va_end (ap);
+
+#if GLIB_CHECK_VERSION(2, 58, 0)
+  /* Since 2.58, g_test_incomplete() sets the exit status correctly. */
+  g_test_incomplete (message);
+#elif GLIB_CHECK_VERSION (2, 38, 0)
+  /* Before 2.58, g_test_incomplete() was treated like a failure for the
+   * purposes of setting the exit status, so prefer to use (our wrapper
+   * around) g_test_skip(). */
+  g_test_skip_printf ("TODO: %s", message);
+#else
+  g_test_message ("TODO: %s", message);
+#endif
+}
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 78, 0)
+void
+_glnx_test_disable_crash_reporting (void)
+{
+  struct rlimit limit = { 0, 0 };
+
+  (void) setrlimit (RLIMIT_CORE, &limit);
+
+  /* On Linux, RLIMIT_CORE = 0 is ignored if core dumps are
+   * configured to be written to a pipe, but PR_SET_DUMPABLE is not. */
+  (void) prctl (PR_SET_DUMPABLE, 0, 0, 0, 0);
+}
+#endif

--- a/subprojects/libglnx/glnx-backport-testutils.h
+++ b/subprojects/libglnx/glnx-backport-testutils.h
@@ -1,0 +1,209 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright 1995-1997 Peter Mattis, Spencer Kimball and Josh MacDonald
+ * Copyright 2015 Colin Walters <walters@verbum.org>
+ * Copyright 2014 Dan Winship
+ * Copyright 2015 Colin Walters
+ * Copyright 2017 Emmanuele Bassi
+ * Copyright 2018-2019 Endless OS Foundation LLC
+ * Copyright 2020 Niels De Graef
+ * Copyright 2021-2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+#include "glnx-backports.h"
+
+G_BEGIN_DECLS
+
+#ifndef g_assert_true       /* added in 2.38 */
+#define g_assert_true(x) g_assert ((x))
+#endif
+
+#ifndef g_assert_false      /* added in 2.38 */
+#define g_assert_false(x) g_assert (!(x))
+#endif
+
+#ifndef g_assert_nonnull    /* added in 2.40 */
+#define g_assert_nonnull(x) g_assert (x != NULL)
+#endif
+
+#ifndef g_assert_null       /* added in 2.40 */
+#define g_assert_null(x) g_assert (x == NULL)
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 38, 0)
+/* Not exactly equivalent, but close enough */
+#define g_test_skip(s) g_test_message ("SKIP: %s", s)
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 58, 0)
+/* Before 2.58, g_test_incomplete() didn't set the exit status correctly */
+#define g_test_incomplete(s) _glnx_test_incomplete_printf ("%s", s)
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 46, 0)
+#define g_assert_cmpmem(m1, l1, m2, l2) G_STMT_START {\
+                                             gconstpointer __m1 = m1, __m2 = m2; \
+                                             int __l1 = l1, __l2 = l2; \
+                                             if (__l1 != 0 && __m1 == NULL) \
+                                               g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                                    "assertion failed (" #l1 " == 0 || " #m1 " != NULL)"); \
+                                             else if (__l2 != 0 && __m2 == NULL) \
+                                               g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                                    "assertion failed (" #l2 " == 0 || " #m2 " != NULL)"); \
+                                             else if (__l1 != __l2) \
+                                               g_assertion_message_cmpnum (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                                           #l1 " (len(" #m1 ")) == " #l2 " (len(" #m2 "))", \
+                                                                           (long double) __l1, "==", (long double) __l2, 'i'); \
+                                             else if (__l1 != 0 && __m2 != NULL && memcmp (__m1, __m2, __l1) != 0) \
+                                               g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                                    "assertion failed (" #m1 " == " #m2 ")"); \
+                                        } G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 58, 0)
+#define g_assert_cmpfloat_with_epsilon(n1,n2,epsilon) \
+                                        G_STMT_START { \
+                                             double __n1 = (n1), __n2 = (n2), __epsilon = (epsilon); \
+                                             if (G_APPROX_VALUE (__n1,  __n2, __epsilon)) ; else \
+                                               g_assertion_message_cmpnum (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                 #n1 " == " #n2 " (+/- " #epsilon ")", __n1, "==", __n2, 'f'); \
+                                        } G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 60, 0)
+#define g_assert_cmpvariant(v1, v2) \
+  G_STMT_START \
+  { \
+    GVariant *__v1 = (v1), *__v2 = (v2); \
+    if (!g_variant_equal (__v1, __v2)) \
+      { \
+        gchar *__s1, *__s2, *__msg; \
+        __s1 = g_variant_print (__v1, TRUE); \
+        __s2 = g_variant_print (__v2, TRUE); \
+        __msg = g_strdup_printf ("assertion failed (" #v1 " == " #v2 "): %s does not equal %s", __s1, __s2); \
+        g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, __msg); \
+        g_free (__s1); \
+        g_free (__s2); \
+        g_free (__msg); \
+      } \
+  } \
+  G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 62, 0)
+/* Not exactly equivalent, but close enough */
+#define g_test_summary(s) g_test_message ("SUMMARY: %s", s)
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 66, 0)
+#define g_assert_no_errno(expr)         G_STMT_START { \
+                                             int __ret, __errsv; \
+                                             errno = 0; \
+                                             __ret = expr; \
+                                             __errsv = errno; \
+                                             if (__ret < 0) \
+                                               { \
+                                                 gchar *__msg; \
+                                                 __msg = g_strdup_printf ("assertion failed (" #expr " >= 0): errno %i: %s", __errsv, g_strerror (__errsv)); \
+                                                 g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, __msg); \
+                                                 g_free (__msg); \
+                                               } \
+                                        } G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 68, 0)
+#define g_assertion_message_cmpstrv _glnx_assertion_message_cmpstrv
+void _glnx_assertion_message_cmpstrv (const char         *domain,
+                                      const char         *file,
+                                      int                 line,
+                                      const char         *func,
+                                      const char         *expr,
+                                      const char * const *arg1,
+                                      const char * const *arg2,
+                                      gsize               first_wrong_idx);
+#define g_assert_cmpstrv(strv1, strv2) \
+  G_STMT_START \
+  { \
+    const char * const *__strv1 = (const char * const *) (strv1); \
+    const char * const *__strv2 = (const char * const *) (strv2); \
+    if (!__strv1 || !__strv2) \
+      { \
+        if (__strv1) \
+          { \
+            g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                 "assertion failed (" #strv1 " == " #strv2 "): " #strv2 " is NULL, but " #strv1 " is not"); \
+          } \
+        else if (__strv2) \
+          { \
+            g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                 "assertion failed (" #strv1 " == " #strv2 "): " #strv1 " is NULL, but " #strv2 " is not"); \
+          } \
+      } \
+    else \
+      { \
+        guint __l1 = g_strv_length ((char **) __strv1); \
+        guint __l2 = g_strv_length ((char **) __strv2); \
+        if (__l1 != __l2) \
+          { \
+            char *__msg; \
+            __msg = g_strdup_printf ("assertion failed (" #strv1 " == " #strv2 "): length %u does not equal length %u", __l1, __l2); \
+            g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, __msg); \
+            g_free (__msg); \
+          } \
+        else \
+          { \
+            guint __i; \
+            for (__i = 0; __i < __l1; __i++) \
+              { \
+                if (g_strcmp0 (__strv1[__i], __strv2[__i]) != 0) \
+                  { \
+                    g_assertion_message_cmpstrv (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                 #strv1 " == " #strv2, \
+                                                 __strv1, __strv2, __i); \
+                  } \
+              } \
+          } \
+      } \
+  } \
+  G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 70, 0)
+/* Before 2.70, diagnostic messages containing newlines were problematic */
+#define g_test_message(...) _glnx_test_message_safe (__VA_ARGS__)
+void _glnx_test_message_safe (const char *format, ...) G_GNUC_PRINTF (1, 2);
+
+#define g_test_fail_printf _glnx_test_fail_printf
+void _glnx_test_fail_printf (const char *format, ...) G_GNUC_PRINTF (1, 2);
+#define g_test_skip_printf _glnx_test_skip_printf
+void _glnx_test_skip_printf (const char *format, ...) G_GNUC_PRINTF (1, 2);
+#define g_test_incomplete_printf _glnx_test_incomplete_printf
+void _glnx_test_incomplete_printf (const char *format, ...) G_GNUC_PRINTF (1, 2);
+#endif
+
+#if !GLIB_CHECK_VERSION (2, 78, 0)
+#define g_test_disable_crash_reporting _glnx_test_disable_crash_reporting
+void _glnx_test_disable_crash_reporting (void);
+#endif
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-backports.c
+++ b/subprojects/libglnx/glnx-backports.c
@@ -1,0 +1,494 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright 2000-2022 Red Hat, Inc.
+ * Copyright 2006-2007 Matthias Clasen
+ * Copyright 2006 Padraig O'Briain
+ * Copyright 2007 Lennart Poettering
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ * Copyright 2018-2022 Endless OS Foundation, LLC
+ * Copyright 2018 Peter Wu
+ * Copyright 2019 Ting-Wei Lan
+ * Copyright 2019 Sebastian Schwarz
+ * Copyright 2020 Matt Rose
+ * Copyright 2021 Casper Dik
+ * Copyright 2022 Alexander Richardson
+ * Copyright 2022 Ray Strode
+ * Copyright 2022 Thomas Haller
+ * Copyright 2023-2024 Collabora Ltd.
+ * Copyright 2023 Sebastian Wilhelmi
+ * Copyright 2023 CaiJingLong
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "libglnx-config.h"
+
+#include "glnx-backports.h"
+#include "glnx-missing.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+gboolean
+glnx_strv_contains (const gchar * const *strv,
+                    const gchar         *str)
+{
+  g_return_val_if_fail (strv != NULL, FALSE);
+  g_return_val_if_fail (str != NULL, FALSE);
+
+  for (; *strv != NULL; strv++)
+    {
+      if (g_str_equal (str, *strv))
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+gboolean
+glnx_set_object (GObject **object_ptr,
+                 GObject  *new_object)
+{
+  GObject *old_object = *object_ptr;
+
+  if (old_object == new_object)
+    return FALSE;
+
+  if (new_object != NULL)
+    g_object_ref (new_object);
+
+  *object_ptr = new_object;
+
+  if (old_object != NULL)
+    g_object_unref (old_object);
+
+  return TRUE;
+}
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 60, 0)
+gboolean
+_glnx_strv_equal (const gchar * const *strv1,
+                  const gchar * const *strv2)
+{
+  g_return_val_if_fail (strv1 != NULL, FALSE);
+  g_return_val_if_fail (strv2 != NULL, FALSE);
+
+  if (strv1 == strv2)
+    return TRUE;
+
+  for (; *strv1 != NULL && *strv2 != NULL; strv1++, strv2++)
+    {
+      if (!g_str_equal (*strv1, *strv2))
+        return FALSE;
+    }
+
+  return (*strv1 == NULL && *strv2 == NULL);
+}
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 80, 0)
+/* This function is called between fork() and exec() and hence must be
+ * async-signal-safe (see signal-safety(7)). */
+static int
+set_cloexec (void *data, gint fd)
+{
+  if (fd >= GPOINTER_TO_INT (data))
+    fcntl (fd, F_SETFD, FD_CLOEXEC);
+
+  return 0;
+}
+
+/* fdwalk()-compatible callback to close a fd for non-compliant
+ * implementations of fdwalk() that potentially pass already
+ * closed fds.
+ *
+ * It is not an error to pass an invalid fd to this function.
+ *
+ * This function is called between fork() and exec() and hence must be
+ * async-signal-safe (see signal-safety(7)).
+ */
+G_GNUC_UNUSED static int
+close_func_with_invalid_fds (void *data, int fd)
+{
+  /* We use close and not g_close here because on some platforms, we
+   * don't know how to close only valid, open file descriptors, so we
+   * have to pass bad fds to close too. g_close warns if given a bad
+   * fd.
+   *
+   * This function returns no error, because there is nothing that the caller
+   * could do with that information. That is even the case for EINTR. See
+   * g_close() about the specialty of EINTR and why that is correct.
+   * If g_close() ever gets extended to handle EINTR specially, then this place
+   * should get updated to do the same handling.
+   */
+  if (fd >= GPOINTER_TO_INT (data))
+    close (fd);
+
+  return 0;
+}
+
+#ifdef __linux__
+struct linux_dirent64
+{
+  guint64        d_ino;    /* 64-bit inode number */
+  guint64        d_off;    /* 64-bit offset to next structure */
+  unsigned short d_reclen; /* Size of this dirent */
+  unsigned char  d_type;   /* File type */
+  char           d_name[]; /* Filename (null-terminated) */
+};
+
+/* This function is called between fork() and exec() and hence must be
+ * async-signal-safe (see signal-safety(7)). */
+static gint
+filename_to_fd (const char *p)
+{
+  char c;
+  int fd = 0;
+  const int cutoff = G_MAXINT / 10;
+  const int cutlim = G_MAXINT % 10;
+
+  if (*p == '\0')
+    return -1;
+
+  while ((c = *p++) != '\0')
+    {
+      if (c < '0' || c > '9')
+        return -1;
+      c -= '0';
+
+      /* Check for overflow. */
+      if (fd > cutoff || (fd == cutoff && c > cutlim))
+        return -1;
+
+      fd = fd * 10 + c;
+    }
+
+  return fd;
+}
+#endif
+
+static int safe_fdwalk_with_invalid_fds (int (*cb)(void *data, int fd), void *data);
+
+/* This function is called between fork() and exec() and hence must be
+ * async-signal-safe (see signal-safety(7)). */
+static int
+safe_fdwalk (int (*cb)(void *data, int fd), void *data)
+{
+#if 0
+  /* Use fdwalk function provided by the system if it is known to be
+   * async-signal safe.
+   *
+   * Currently there are no operating systems known to provide a safe
+   * implementation, so this section is not used for now.
+   */
+  return fdwalk (cb, data);
+#else
+  /* Fallback implementation of fdwalk. It should be async-signal safe, but it
+   * may fail on non-Linux operating systems. See safe_fdwalk_with_invalid_fds
+   * for a slower alternative.
+   */
+
+#ifdef __linux__
+  gint fd;
+  gint res = 0;
+
+  /* Avoid use of opendir/closedir since these are not async-signal-safe. */
+  int dir_fd = open ("/proc/self/fd", O_RDONLY | O_DIRECTORY);
+  if (dir_fd >= 0)
+    {
+      /* buf needs to be aligned correctly to receive linux_dirent64.
+       * C11 has _Alignof for this purpose, but for now a
+       * union serves the same purpose. */
+      union
+      {
+        char buf[4096];
+        struct linux_dirent64 alignment;
+      } u;
+      int pos, nread;
+      struct linux_dirent64 *de;
+
+      while ((nread = syscall (SYS_getdents64, dir_fd, u.buf, sizeof (u.buf))) > 0)
+        {
+          for (pos = 0; pos < nread; pos += de->d_reclen)
+            {
+              de = (struct linux_dirent64 *) (u.buf + pos);
+
+              fd = filename_to_fd (de->d_name);
+              if (fd < 0 || fd == dir_fd)
+                  continue;
+
+              if ((res = cb (data, fd)) != 0)
+                  break;
+            }
+        }
+
+      close (dir_fd);
+      return res;
+    }
+
+  /* If /proc is not mounted or not accessible we fail here and rely on
+   * safe_fdwalk_with_invalid_fds to fall back to the old
+   * rlimit trick. */
+
+#endif
+
+#if defined(__sun__) && defined(F_PREVFD) && defined(F_NEXTFD)
+/*
+ * Solaris 11.4 has a signal-safe way which allows
+ * us to find all file descriptors in a process.
+ *
+ * fcntl(fd, F_NEXTFD, maxfd)
+ * - returns the first allocated file descriptor <= maxfd  > fd.
+ *
+ * fcntl(fd, F_PREVFD)
+ * - return highest allocated file descriptor < fd.
+ */
+  gint fd;
+  gint res = 0;
+
+  open_max = fcntl (INT_MAX, F_PREVFD); /* find the maximum fd */
+  if (open_max < 0) /* No open files */
+    return 0;
+
+  for (fd = -1; (fd = fcntl (fd, F_NEXTFD, open_max)) != -1; )
+    if ((res = cb (data, fd)) != 0 || fd == open_max)
+      break;
+
+  return res;
+#endif
+
+  return safe_fdwalk_with_invalid_fds (cb, data);
+#endif
+}
+
+/* This function is called between fork() and exec() and hence must be
+ * async-signal-safe (see signal-safety(7)). */
+static int
+safe_fdwalk_with_invalid_fds (int (*cb)(void *data, int fd), void *data)
+{
+  /* Fallback implementation of fdwalk. It should be async-signal safe, but it
+   * may be slow, especially on systems allowing very high number of open file
+   * descriptors.
+   */
+  gint open_max = -1;
+  gint fd;
+  gint res = 0;
+
+#if 0 && defined(HAVE_SYS_RESOURCE_H)
+  struct rlimit rl;
+
+  /* Use getrlimit() function provided by the system if it is known to be
+   * async-signal safe.
+   *
+   * Currently there are no operating systems known to provide a safe
+   * implementation, so this section is not used for now.
+   */
+  if (getrlimit (RLIMIT_NOFILE, &rl) == 0 && rl.rlim_max != RLIM_INFINITY)
+    open_max = rl.rlim_max;
+#endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+  /* Use sysconf() function provided by the system if it is known to be
+   * async-signal safe.
+   *
+   * FreeBSD: sysconf() is included in the list of async-signal safe functions
+   * found in https://man.freebsd.org/sigaction(2).
+   *
+   * OpenBSD: sysconf() is included in the list of async-signal safe functions
+   * found in https://man.openbsd.org/sigaction.2.
+   *
+   * Apple: sysconf() is included in the list of async-signal safe functions
+   * found in https://opensource.apple.com/source/xnu/xnu-517.12.7/bsd/man/man2/sigaction.2
+   */
+  if (open_max < 0)
+    open_max = sysconf (_SC_OPEN_MAX);
+#endif
+  /* Hardcoded fallback: the default process hard limit in Linux as of 2020 */
+  if (open_max < 0)
+    open_max = 4096;
+
+#if defined(__APPLE__) && defined(HAVE_LIBPROC_H)
+  /* proc_pidinfo isn't documented as async-signal-safe but looking at the implementation
+   * in the darwin tree here:
+   *
+   * https://opensource.apple.com/source/Libc/Libc-498/darwin/libproc.c.auto.html
+   *
+   * It's just a thin wrapper around a syscall, so it's probably okay.
+   */
+  {
+    char buffer[4096 * PROC_PIDLISTFD_SIZE];
+    ssize_t buffer_size;
+
+    buffer_size = proc_pidinfo (getpid (), PROC_PIDLISTFDS, 0, buffer, sizeof (buffer));
+
+    if (buffer_size > 0 &&
+        sizeof (buffer) >= (size_t) buffer_size &&
+        (buffer_size % PROC_PIDLISTFD_SIZE) == 0)
+      {
+        const struct proc_fdinfo *fd_info = (const struct proc_fdinfo *) buffer;
+        size_t number_of_fds = (size_t) buffer_size / PROC_PIDLISTFD_SIZE;
+
+        for (size_t i = 0; i < number_of_fds; i++)
+          if ((res = cb (data, fd_info[i].proc_fd)) != 0)
+            break;
+
+        return res;
+      }
+  }
+#endif
+
+  for (fd = 0; fd < open_max; fd++)
+      if ((res = cb (data, fd)) != 0)
+          break;
+
+  return res;
+}
+
+/**
+ * g_fdwalk_set_cloexec:
+ * @lowfd: Minimum fd to act on, which must be non-negative
+ *
+ * Mark every file descriptor equal to or greater than @lowfd to be closed
+ * at the next `execve()` or similar, as if via the `FD_CLOEXEC` flag.
+ *
+ * Typically @lowfd will be 3, to leave standard input, standard output
+ * and standard error open after exec.
+ *
+ * This is the same as Linux `close_range (lowfd, ~0U, CLOSE_RANGE_CLOEXEC)`,
+ * but portable to other OSs and to older versions of Linux.
+ *
+ * This function is async-signal safe, making it safe to call from a
+ * signal handler or a [callback@GLib.SpawnChildSetupFunc], as long as @lowfd is
+ * non-negative.
+ * See [`signal(7)`](man:signal(7)) and
+ * [`signal-safety(7)`](man:signal-safety(7)) for more details.
+ *
+ * Returns: 0 on success, -1 with errno set on error
+ * Since: 2.80
+ */
+int
+_glnx_fdwalk_set_cloexec (int lowfd)
+{
+  int ret;
+
+  g_return_val_if_fail (lowfd >= 0, (errno = EINVAL, -1));
+
+#if defined(HAVE_CLOSE_RANGE) && defined(CLOSE_RANGE_CLOEXEC)
+  /* close_range() is available in Linux since kernel 5.9, and on FreeBSD at
+   * around the same time. It was designed for use in async-signal-safe
+   * situations: https://bugs.python.org/issue38061
+   *
+   * The `CLOSE_RANGE_CLOEXEC` flag was added in Linux 5.11, and is not yet
+   * present in FreeBSD.
+   *
+   * Handle ENOSYS in case it’s supported in libc but not the kernel; if so,
+   * fall back to safe_fdwalk(). Handle EINVAL in case `CLOSE_RANGE_CLOEXEC`
+   * is not supported. */
+  ret = close_range (lowfd, G_MAXUINT, CLOSE_RANGE_CLOEXEC);
+  if (ret == 0 || !(errno == ENOSYS || errno == EINVAL))
+    return ret;
+#endif  /* HAVE_CLOSE_RANGE */
+
+  ret = safe_fdwalk (set_cloexec, GINT_TO_POINTER (lowfd));
+
+  return ret;
+}
+
+/**
+ * g_closefrom:
+ * @lowfd: Minimum fd to close, which must be non-negative
+ *
+ * Close every file descriptor equal to or greater than @lowfd.
+ *
+ * Typically @lowfd will be 3, to leave standard input, standard output
+ * and standard error open.
+ *
+ * This is the same as Linux `close_range (lowfd, ~0U, 0)`,
+ * but portable to other OSs and to older versions of Linux.
+ * Equivalently, it is the same as BSD `closefrom (lowfd)`, but portable,
+ * and async-signal-safe on all OSs.
+ *
+ * This function is async-signal safe, making it safe to call from a
+ * signal handler or a [callback@GLib.SpawnChildSetupFunc], as long as @lowfd is
+ * non-negative.
+ * See [`signal(7)`](man:signal(7)) and
+ * [`signal-safety(7)`](man:signal-safety(7)) for more details.
+ *
+ * Returns: 0 on success, -1 with errno set on error
+ * Since: 2.80
+ */
+int
+_glnx_closefrom (int lowfd)
+{
+  int ret;
+
+  g_return_val_if_fail (lowfd >= 0, (errno = EINVAL, -1));
+
+#if defined(HAVE_CLOSE_RANGE)
+  /* close_range() is available in Linux since kernel 5.9, and on FreeBSD at
+   * around the same time. It was designed for use in async-signal-safe
+   * situations: https://bugs.python.org/issue38061
+   *
+   * Handle ENOSYS in case it’s supported in libc but not the kernel; if so,
+   * fall back to safe_fdwalk(). */
+  ret = close_range (lowfd, G_MAXUINT, 0);
+  if (ret == 0 || errno != ENOSYS)
+    return ret;
+#endif  /* HAVE_CLOSE_RANGE */
+
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || \
+  (defined(__sun__) && defined(F_CLOSEFROM))
+  /* Use closefrom function provided by the system if it is known to be
+   * async-signal safe.
+   *
+   * FreeBSD: closefrom is included in the list of async-signal safe functions
+   * found in https://man.freebsd.org/sigaction(2).
+   *
+   * OpenBSD: closefrom is not included in the list, but a direct system call
+   * should be safe to use.
+   *
+   * In Solaris as of 11.3 SRU 31, closefrom() is also a direct system call.
+   * On such systems, F_CLOSEFROM is defined.
+   */
+  (void) closefrom (lowfd);
+  return 0;
+#elif defined(__DragonFly__)
+  /* It is unclear whether closefrom function included in DragonFlyBSD libc_r
+   * is safe to use because it calls a lot of library functions. It is also
+   * unclear whether libc_r itself is still being used. Therefore, we do a
+   * direct system call here ourselves to avoid possible issues.
+   */
+  (void) syscall (SYS_closefrom, lowfd);
+  return 0;
+#elif defined(F_CLOSEM)
+  /* NetBSD and AIX have a special fcntl command which does the same thing as
+   * closefrom. NetBSD also includes closefrom function, which seems to be a
+   * simple wrapper of the fcntl command.
+   */
+  return fcntl (lowfd, F_CLOSEM);
+#else
+  ret = safe_fdwalk (close_func_with_invalid_fds, GINT_TO_POINTER (lowfd));
+
+  return ret;
+#endif
+}
+#endif /* !2.80.0 */

--- a/subprojects/libglnx/glnx-backports.h
+++ b/subprojects/libglnx/glnx-backports.h
@@ -1,0 +1,159 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright 1998 Manish Singh
+ * Copyright 1998 Tim Janik
+ * Copyright (C) 2015 Colin Walters <walters@verbum.org>
+ * Copyright (C) 2018 Endless OS Foundation, LLC
+ * Copyright 2017 Emmanuele Bassi
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * 
+ * GLIB - Library of useful routines for C programming
+ * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string.h>
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#if !GLIB_CHECK_VERSION(2, 34, 0)
+#define g_clear_pointer(pp, destroy) \
+  G_STMT_START {                                                               \
+    G_STATIC_ASSERT (sizeof *(pp) == sizeof (gpointer));                       \
+    /* Only one access, please; work around type aliasing */                   \
+    union { char *in; gpointer *out; } _pp;                                    \
+    gpointer _p;                                                               \
+    /* This assignment is needed to avoid a gcc warning */                     \
+    GDestroyNotify _destroy = (GDestroyNotify) (destroy);                      \
+                                                                               \
+    _pp.in = (char *) (pp);                                                    \
+    _p = *_pp.out;                                                             \
+    if (_p)                                                                    \
+      {                                                                        \
+        *_pp.out = NULL;                                                       \
+        _destroy (_p);                                                         \
+      }                                                                        \
+  } G_STMT_END
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 40, 0)
+#define g_info(...) g_log (G_LOG_DOMAIN, G_LOG_LEVEL_INFO, __VA_ARGS__)
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 44, 0)
+
+#define g_strv_contains glnx_strv_contains
+gboolean              glnx_strv_contains  (const gchar * const *strv,
+                                           const gchar         *str);
+
+#define g_set_object(object_ptr, new_object) \
+ (/* Check types match. */ \
+  0 ? *(object_ptr) = (new_object), FALSE : \
+  glnx_set_object ((GObject **) (object_ptr), (GObject *) (new_object)) \
+ )
+gboolean              glnx_set_object  (GObject **object_ptr,
+                                        GObject  *new_object);
+
+#endif /* !GLIB_CHECK_VERSION(2, 44, 0) */
+
+#if !GLIB_CHECK_VERSION(2, 38, 0)
+#define G_SPAWN_DEFAULT ((GSpawnFlags) 0)
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 42, 0)
+#define G_OPTION_FLAG_NONE ((GOptionFlags) 0)
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 60, 0)
+#define g_strv_equal _glnx_strv_equal
+gboolean _glnx_strv_equal (const gchar * const *strv1,
+                           const gchar * const *strv2);
+#endif
+
+#ifndef G_DBUS_METHOD_INVOCATION_HANDLED    /* added in 2.68 */
+#define G_DBUS_METHOD_INVOCATION_HANDLED TRUE
+#endif
+
+#ifndef G_DBUS_METHOD_INVOCATION_UNHANDLED  /* added in 2.68 */
+#define G_DBUS_METHOD_INVOCATION_UNHANDLED FALSE
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+static inline gpointer _glnx_memdup2 (gconstpointer mem,
+                                      gsize         byte_size) G_GNUC_ALLOC_SIZE(2);
+static inline gpointer
+_glnx_memdup2 (gconstpointer mem,
+               gsize         byte_size)
+{
+  gpointer new_mem;
+
+  if (mem && byte_size != 0)
+    {
+      new_mem = g_malloc (byte_size);
+      memcpy (new_mem, mem, byte_size);
+    }
+  else
+    new_mem = NULL;
+
+  return new_mem;
+}
+#define g_memdup2 _glnx_memdup2
+#endif
+
+#ifndef G_OPTION_ENTRY_NULL   /* added in 2.70 */
+#define G_OPTION_ENTRY_NULL { NULL, 0, 0, 0, NULL, NULL, NULL }
+#endif
+
+#ifndef G_APPROX_VALUE  /* added in 2.58 */
+#define G_APPROX_VALUE(a, b, epsilon) \
+  (((a) > (b) ? (a) - (b) : (b) - (a)) < (epsilon))
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 70, 0)
+#define g_steal_fd _glnx_steal_fd
+static inline int
+_glnx_steal_fd (int *fdp)
+{
+  int fd = *fdp;
+  *fdp = -1;
+  return fd;
+}
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 74, 0)
+#define G_APPLICATION_DEFAULT_FLAGS ((GApplicationFlags) 0)
+#define G_CONNECT_DEFAULT ((GConnectFlags) 0)
+#define G_IO_FLAG_NONE ((GIOFlags) 0)
+#define G_MARKUP_DEFAULT_FLAGS ((GMarkupParseFlags) 0)
+#define G_REGEX_DEFAULT ((GRegexCompileFlags) 0)
+#define G_REGEX_MATCH_DEFAULT ((GRegexMatchFlags) 0)
+#define G_TEST_SUBPROCESS_DEFAULT ((GTestSubprocessFlags) 0)
+#define G_TEST_TRAP_DEFAULT ((GTestTrapFlags) 0)
+#define G_TLS_CERTIFICATE_NO_FLAGS ((GTlsCertificateFlags) 0)
+#define G_TYPE_FLAG_NONE ((GTypeFlags) 0)
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 80, 0)
+#define g_closefrom _glnx_closefrom
+int _glnx_closefrom (int lowfd);
+#define g_fdwalk_set_cloexec _glnx_fdwalk_set_cloexec
+int _glnx_fdwalk_set_cloexec (int lowfd);
+#endif
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-backports.h
+++ b/subprojects/libglnx/glnx-backports.h
@@ -80,6 +80,10 @@ gboolean              glnx_set_object  (GObject **object_ptr,
 #define G_OPTION_FLAG_NONE ((GOptionFlags) 0)
 #endif
 
+#ifndef G_PID_FORMAT  /* added in 2.50 */
+#define G_PID_FORMAT "i"
+#endif
+
 #if !GLIB_CHECK_VERSION(2, 60, 0)
 #define g_strv_equal _glnx_strv_equal
 gboolean _glnx_strv_equal (const gchar * const *strv1,
@@ -125,16 +129,22 @@ _glnx_memdup2 (gconstpointer mem,
   (((a) > (b) ? (a) - (b) : (b) - (a)) < (epsilon))
 #endif
 
-#if !GLIB_CHECK_VERSION(2, 70, 0)
-#define g_steal_fd _glnx_steal_fd
 static inline int
 _glnx_steal_fd (int *fdp)
 {
+#if GLIB_CHECK_VERSION(2, 70, 0)
+  /* Allow it to be used without deprecation warnings, even if the target
+   * GLib version is older */
+  G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+  return g_steal_fd (fdp);
+  G_GNUC_END_IGNORE_DEPRECATIONS
+#else
   int fd = *fdp;
   *fdp = -1;
   return fd;
-}
 #endif
+}
+#define g_steal_fd _glnx_steal_fd
 
 #if !GLIB_CHECK_VERSION(2, 74, 0)
 #define G_APPLICATION_DEFAULT_FLAGS ((GApplicationFlags) 0)

--- a/subprojects/libglnx/glnx-console.c
+++ b/subprojects/libglnx/glnx-console.c
@@ -1,0 +1,360 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2013,2014,2015 Colin Walters <walters@verbum.org>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include "glnx-console.h"
+
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/ioctl.h>
+
+/* For people with widescreen monitors and maximized terminals, it looks pretty
+ * bad to have an enormous progress bar. For much the same reason as web pages
+ * tend to have a maximum width;
+ * https://ux.stackexchange.com/questions/48982/suggest-good-max-width-for-fluid-width-design
+ */
+#define MAX_PROGRESSBAR_COLUMNS 20
+
+/* Max updates output per second.  On a tty there's no point to rendering
+ * extremely fast; and for a non-tty we're probably in a Jenkins job
+ * or whatever and having percentages spam multiple lines there is annoying.
+ */
+#define MAX_TTY_UPDATE_HZ (5)
+#define MAX_NONTTY_UPDATE_HZ (1)
+
+static gboolean locked;
+static guint64 last_update_ms; /* monotonic time in millis we last updated */
+
+gboolean
+glnx_stdout_is_tty (void)
+{
+  static gsize initialized = 0;
+  static gboolean stdout_is_tty_v;
+
+  if (g_once_init_enter (&initialized))
+    {
+      stdout_is_tty_v = isatty (1);
+      g_once_init_leave (&initialized, 1);
+    }
+
+  return stdout_is_tty_v;
+}
+
+static volatile guint cached_columns = 0;
+static volatile guint cached_lines = 0;
+
+static int
+fd_columns (int fd)
+{
+  struct winsize ws = {};
+
+  if (ioctl (fd, TIOCGWINSZ, &ws) < 0)
+    return -errno;
+
+  if (ws.ws_col <= 0)
+    return -EIO;
+
+  return ws.ws_col;
+}
+
+/**
+ * glnx_console_columns:
+ * 
+ * Returns: The number of columns for terminal output
+ */
+guint
+glnx_console_columns (void)
+{
+  if (G_UNLIKELY (cached_columns == 0))
+    {
+      int c;
+
+      c = fd_columns (STDOUT_FILENO);
+
+      if (c <= 0)
+        c = 80;
+
+      if (c > 256)
+        c = 256;
+
+      cached_columns = c;
+    }
+
+  return cached_columns;
+}
+
+static int
+fd_lines (int fd)
+{
+  struct winsize ws = {};
+
+  if (ioctl (fd, TIOCGWINSZ, &ws) < 0)
+    return -errno;
+
+  if (ws.ws_row <= 0)
+    return -EIO;
+
+  return ws.ws_row;
+}
+
+/**
+ * glnx_console_lines:
+ * 
+ * Returns: The number of lines for terminal output
+ */
+guint
+glnx_console_lines (void)
+{
+  if (G_UNLIKELY (cached_lines == 0))
+    {
+      int l;
+
+      l = fd_lines (STDOUT_FILENO);
+
+      if (l <= 0)
+        l = 24;
+
+      cached_lines = l;
+    }
+
+  return cached_lines;
+}
+
+static void
+on_sigwinch (G_GNUC_UNUSED int signum)
+{
+  cached_columns = 0;
+  cached_lines = 0;
+}
+
+void
+glnx_console_lock (GLnxConsoleRef *console)
+{
+  static gsize sigwinch_initialized = 0;
+
+  g_return_if_fail (!locked);
+  g_return_if_fail (!console->locked);
+
+  console->is_tty = glnx_stdout_is_tty ();
+
+  locked = console->locked = TRUE;
+
+  if (console->is_tty)
+    {
+      if (g_once_init_enter (&sigwinch_initialized))
+        {
+          signal (SIGWINCH, on_sigwinch);
+          g_once_init_leave (&sigwinch_initialized, 1);
+        }
+      
+      { static const char initbuf[] = { 0x1B, 0x37 };
+        (void) fwrite (initbuf, 1, sizeof (initbuf), stdout);
+      }
+    }
+}
+
+static void
+printpad (const char *padbuf,
+          guint       padbuf_len,
+          guint       n)
+{
+  const guint d = n / padbuf_len;
+  const guint r = n % padbuf_len;
+  guint i;
+
+  for (i = 0; i < d; i++)
+    fwrite (padbuf, 1, padbuf_len, stdout);
+  fwrite (padbuf, 1, r, stdout);
+}
+
+static void
+text_percent_internal (const char *text,
+                       int percentage)
+{
+  /* Check whether we're trying to render too fast; unless percentage is 100, in
+   * which case we assume this is the last call, so we always render it.
+   */
+  const guint64 current_ms = g_get_monotonic_time () / 1000;
+  if (percentage != 100)
+    {
+      const guint64 diff_ms = current_ms - last_update_ms;
+      if (glnx_stdout_is_tty ())
+        {
+          if (diff_ms < (1000/MAX_TTY_UPDATE_HZ))
+            return;
+        }
+      else
+        {
+          if (diff_ms < (1000/MAX_NONTTY_UPDATE_HZ))
+            return;
+        }
+    }
+  last_update_ms = current_ms;
+
+  static const char equals[] = "====================";
+  const guint n_equals = sizeof (equals) - 1;
+  static const char spaces[] = "                    ";
+  const guint n_spaces = sizeof (spaces) - 1;
+  const guint ncolumns = glnx_console_columns ();
+  const guint bar_min = 10;
+
+  if (text && !*text)
+    text = NULL;
+
+  const guint input_textlen = text ? strlen (text) : 0;
+
+  if (!glnx_stdout_is_tty ())
+    {
+      if (text)
+        fprintf (stdout, "%s", text);
+      if (percentage != -1)
+        {
+          if (text)
+            fputc (' ', stdout);
+          fprintf (stdout, "%u%%", percentage);
+        }
+      fputc ('\n', stdout);
+      fflush (stdout);
+      return;
+    }
+
+  if (ncolumns < bar_min)
+    return; /* TODO: spinner */
+
+  /* Restore cursor */
+  { const char beginbuf[2] = { 0x1B, 0x38 };
+    (void) fwrite (beginbuf, 1, sizeof (beginbuf), stdout);
+  }
+
+  if (percentage == -1)
+    {
+      if (text != NULL)
+        fwrite (text, 1, input_textlen, stdout);
+
+      /* Overwrite remaining space, if any */
+      if (ncolumns > input_textlen)
+        printpad (spaces, n_spaces, ncolumns - input_textlen);
+    }
+  else
+    {
+      const guint textlen = MIN (input_textlen, ncolumns - bar_min);
+      const guint barlen = MIN (MAX_PROGRESSBAR_COLUMNS, ncolumns - (textlen + 1));
+
+      if (text && textlen > 0)
+        {
+          fwrite (text, 1, textlen, stdout);
+          fputc (' ', stdout);
+        }
+
+      {
+        const guint nbraces = 2;
+        const guint textpercent_len = 5;
+        const guint bar_internal_len = barlen - nbraces - textpercent_len;
+        const guint eqlen = bar_internal_len * (percentage / 100.0);
+        const guint spacelen = bar_internal_len - eqlen;
+
+        fputc ('[', stdout);
+        printpad (equals, n_equals, eqlen);
+        printpad (spaces, n_spaces, spacelen);
+        fputc (']', stdout);
+        fprintf (stdout, " %3d%%", percentage);
+      }
+    }
+
+  fflush (stdout);
+}
+
+/**
+ * glnx_console_progress_text_percent:
+ * @text: Show this text before the progress bar
+ * @percentage: An integer in the range of 0 to 100
+ *
+ * On a tty, print to the console @text followed by an ASCII art
+ * progress bar whose percentage is @percentage.  If stdout is not a
+ * tty, a more basic line by line change will be printed.
+ *
+ * You must have called glnx_console_lock() before invoking this
+ * function.
+ *
+ */
+void
+glnx_console_progress_text_percent (const char *text,
+                                    guint percentage)
+{
+  g_return_if_fail (percentage <= 100);
+
+  text_percent_internal (text, percentage);
+}
+
+/**
+ * glnx_console_progress_n_items:
+ * @text: Show this text before the progress bar
+ * @current: An integer for how many items have been processed
+ * @total: An integer for how many items there are total
+ *
+ * On a tty, print to the console @text followed by [@current/@total],
+ * then an ASCII art progress bar, like glnx_console_progress_text_percent().
+ *
+ * You must have called glnx_console_lock() before invoking this
+ * function.
+ */
+void
+glnx_console_progress_n_items (const char     *text,
+                               guint           current,
+                               guint           total)
+{
+  g_return_if_fail (current <= total);
+  g_return_if_fail (total > 0);
+
+  g_autofree char *newtext = g_strdup_printf ("%s (%u/%u)", text, current, total);
+  /* Special case current == total to ensure we end at 100% */
+  int percentage = (current == total) ? 100 : (((double)current) / total * 100);
+  glnx_console_progress_text_percent (newtext, percentage);
+}
+
+void
+glnx_console_text (const char *text)
+{
+  text_percent_internal (text, -1);
+}
+
+/**
+ * glnx_console_unlock:
+ *
+ * Print a newline, and reset all cached console progress state.
+ *
+ * This function does nothing if stdout is not a tty.
+ */
+void
+glnx_console_unlock (GLnxConsoleRef *console)
+{
+  g_return_if_fail (locked);
+  g_return_if_fail (console->locked);
+
+  if (console->is_tty)
+    fputc ('\n', stdout);
+      
+  locked = console->locked = FALSE;
+}

--- a/subprojects/libglnx/glnx-console.h
+++ b/subprojects/libglnx/glnx-console.h
@@ -1,0 +1,62 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2013,2014,2015 Colin Walters <walters@verbum.org>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2 of the licence or (at
+ * your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-backport-autocleanups.h>
+
+G_BEGIN_DECLS
+
+struct GLnxConsoleRef {
+  gboolean locked;
+  gboolean is_tty;
+};
+
+typedef struct GLnxConsoleRef GLnxConsoleRef;
+
+gboolean glnx_stdout_is_tty (void);
+
+void	 glnx_console_lock (GLnxConsoleRef *ref);
+
+void	 glnx_console_text (const char     *text);
+
+void	 glnx_console_progress_text_percent (const char     *text,
+                                           guint           percentage);
+
+void	 glnx_console_progress_n_items (const char     *text,
+                                      guint           current,
+                                      guint           total);
+
+void	 glnx_console_unlock (GLnxConsoleRef *ref);
+
+guint    glnx_console_lines (void);
+
+guint    glnx_console_columns (void);
+
+static inline void
+glnx_console_ref_cleanup (GLnxConsoleRef *p)
+{
+  if (p->locked)
+    glnx_console_unlock (p);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxConsoleRef, glnx_console_ref_cleanup)
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-dirfd.c
+++ b/subprojects/libglnx/glnx-dirfd.c
@@ -1,0 +1,444 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <string.h>
+
+#include <glnx-dirfd.h>
+#include <glnx-fdio.h>
+#include <glnx-errors.h>
+#include <glnx-local-alloc.h>
+#include <glnx-shutil.h>
+
+/**
+ * glnx_opendirat_with_errno:
+ * @dfd: File descriptor for origin directory
+ * @name: Pathname, relative to @dfd
+ * @follow: Whether or not to follow symbolic links
+ *
+ * Use openat() to open a directory, using a standard set of flags.
+ * This function sets errno.
+ */
+int
+glnx_opendirat_with_errno (int           dfd,
+                           const char   *path,
+                           gboolean      follow)
+{
+  int flags = O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOCTTY;
+  if (!follow)
+    flags |= O_NOFOLLOW;
+
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  return openat (dfd, path, flags);
+}
+
+/**
+ * glnx_opendirat:
+ * @dfd: File descriptor for origin directory
+ * @path: Pathname, relative to @dfd
+ * @follow: Whether or not to follow symbolic links
+ * @error: Error
+ *
+ * Use openat() to open a directory, using a standard set of flags.
+ */
+gboolean
+glnx_opendirat (int             dfd,
+                const char     *path,
+                gboolean        follow,
+                int            *out_fd,
+                GError        **error)
+{
+  int ret = glnx_opendirat_with_errno (dfd, path, follow);
+  if (ret == -1)
+    return glnx_throw_errno_prefix (error, "opendir(%s)", path);
+  *out_fd = ret;
+  return TRUE;
+}
+
+struct GLnxRealDirfdIterator
+{
+  gboolean initialized;
+  int fd;
+  DIR *d;
+};
+typedef struct GLnxRealDirfdIterator GLnxRealDirfdIterator;
+
+/**
+ * glnx_dirfd_iterator_init_at:
+ * @dfd: File descriptor, may be AT_FDCWD or -1
+ * @path: Path, may be relative to @dfd
+ * @follow: If %TRUE and the last component of @path is a symlink, follow it
+ * @out_dfd_iter: (out caller-allocates): A directory iterator, will be initialized
+ * @error: Error
+ *
+ * Initialize @out_dfd_iter from @dfd and @path.
+ */
+gboolean
+glnx_dirfd_iterator_init_at (int                     dfd,
+                             const char             *path,
+                             gboolean                follow,
+                             GLnxDirFdIterator      *out_dfd_iter,
+                             GError                **error)
+{
+  glnx_autofd int fd = -1;
+  if (!glnx_opendirat (dfd, path, follow, &fd, error))
+    return FALSE;
+
+  if (!glnx_dirfd_iterator_init_take_fd (&fd, out_dfd_iter, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * glnx_dirfd_iterator_init_take_fd:
+ * @dfd: File descriptor - ownership is taken, and the value is set to -1
+ * @dfd_iter: A directory iterator
+ * @error: Error
+ *
+ * Steal ownership of @dfd, using it to initialize @dfd_iter for
+ * iteration.
+ */
+gboolean
+glnx_dirfd_iterator_init_take_fd (int               *dfd,
+                                  GLnxDirFdIterator *dfd_iter,
+                                  GError           **error)
+{
+  GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
+  DIR *d = fdopendir (*dfd);
+  if (!d)
+    return glnx_throw_errno_prefix (error, "fdopendir");
+
+  real_dfd_iter->fd = g_steal_fd (dfd);
+  real_dfd_iter->d = d;
+  real_dfd_iter->initialized = TRUE;
+
+  return TRUE;
+}
+
+/**
+ * glnx_dirfd_iterator_next_dent:
+ * @dfd_iter: A directory iterator
+ * @out_dent: (out) (transfer none): Pointer to dirent; do not free
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Read the next value from @dfd_iter, causing @out_dent to be
+ * updated.  If end of stream is reached, @out_dent will be set
+ * to %NULL, and %TRUE will be returned.
+ */
+gboolean
+glnx_dirfd_iterator_next_dent (GLnxDirFdIterator  *dfd_iter,
+                               struct dirent     **out_dent,
+                               GCancellable       *cancellable,
+                               GError             **error)
+{
+  GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
+
+  g_return_val_if_fail (out_dent, FALSE);
+  g_return_val_if_fail (dfd_iter->initialized, FALSE);
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+  do
+    {
+      errno = 0;
+      *out_dent = readdir (real_dfd_iter->d);
+      if (*out_dent == NULL && errno != 0)
+        return glnx_throw_errno_prefix (error, "readdir");
+    } while (*out_dent &&
+             (strcmp ((*out_dent)->d_name, ".") == 0 ||
+              strcmp ((*out_dent)->d_name, "..") == 0));
+
+  return TRUE;
+}
+
+/**
+ * glnx_dirfd_iterator_rewind:
+ * @dfd_iter: A directory iterator
+ *
+ * Rewind to the beginning of @dfd_iter. The next call to
+ * glnx_dirfd_iterator_next_dent() will provide the first entry in the
+ * directory.
+ */
+void
+glnx_dirfd_iterator_rewind (GLnxDirFdIterator  *dfd_iter)
+{
+  GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
+
+  g_return_if_fail (dfd_iter->initialized);
+
+  rewinddir (real_dfd_iter->d);
+}
+
+/**
+ * glnx_dirfd_iterator_next_dent_ensure_dtype:
+ * @dfd_iter: A directory iterator
+ * @out_dent: (out) (transfer none): Pointer to dirent; do not free
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * A variant of @glnx_dirfd_iterator_next_dent, which will ensure the
+ * `dent->d_type` member is filled in by calling `fstatat`
+ * automatically if the underlying filesystem type sets `DT_UNKNOWN`.
+ */
+gboolean
+glnx_dirfd_iterator_next_dent_ensure_dtype (GLnxDirFdIterator  *dfd_iter,
+                                            struct dirent     **out_dent,
+                                            GCancellable       *cancellable,
+                                            GError            **error)
+{
+  g_return_val_if_fail (out_dent, FALSE);
+
+  if (!glnx_dirfd_iterator_next_dent (dfd_iter, out_dent, cancellable, error))
+    return FALSE;
+
+  struct dirent *ret_dent = *out_dent;
+  if (ret_dent)
+    {
+
+      if (ret_dent->d_type == DT_UNKNOWN)
+        {
+          struct stat stbuf;
+          if (!glnx_fstatat (dfd_iter->fd, ret_dent->d_name, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+            return FALSE;
+          ret_dent->d_type = IFTODT (stbuf.st_mode);
+        }
+    }
+
+  return TRUE;
+}
+
+/**
+ * glnx_dirfd_iterator_clear:
+ * @dfd_iter: Iterator, will be de-initialized
+ *
+ * Unset @dfd_iter, freeing any resources.  If @dfd_iter is not
+ * initialized, do nothing.
+ */
+void
+glnx_dirfd_iterator_clear (GLnxDirFdIterator *dfd_iter)
+{
+  GLnxRealDirfdIterator *real_dfd_iter = (GLnxRealDirfdIterator*) dfd_iter;
+  /* fd is owned by dfd_iter */
+  if (!real_dfd_iter->initialized)
+    return;
+  (void) closedir (real_dfd_iter->d);
+  real_dfd_iter->initialized = FALSE;
+}
+
+/**
+ * glnx_fdrel_abspath:
+ * @dfd: Directory fd
+ * @path: Path
+ *
+ * Turn a fd-relative pair into something that can be used for legacy
+ * APIs expecting absolute paths.
+ *
+ * This is Linux specific, and only valid inside this process (unless
+ * you set up the child process to have the exact same fd number, but
+ * don't try that).
+ */
+char *
+glnx_fdrel_abspath (int         dfd,
+                    const char *path)
+{
+  dfd = glnx_dirfd_canonicalize (dfd);
+  if (dfd == AT_FDCWD)
+    return g_strdup (path);
+  return g_strdup_printf ("/proc/self/fd/%d/%s", dfd, path);
+}
+
+/**
+ * glnx_gen_temp_name:
+ * @tmpl: (type filename): template directory name, the last 6 characters will be replaced
+ *
+ * Replace the last 6 characters of @tmpl with random ASCII.  You must
+ * use this in combination with a mechanism to ensure race-free file
+ * creation such as `O_EXCL`.
+ */
+void
+glnx_gen_temp_name (gchar *tmpl)
+{
+  g_return_if_fail (tmpl != NULL);
+  const size_t len = strlen (tmpl);
+  g_return_if_fail (len >= 6);
+
+  static const char letters[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  static const int NLETTERS = sizeof (letters) - 1;
+
+  char *XXXXXX = tmpl + (len - 6);
+  for (int i = 0; i < 6; i++)
+    XXXXXX[i] = letters[g_random_int_range(0, NLETTERS)];
+}
+
+/**
+ * glnx_mkdtempat:
+ * @dfd: Directory fd
+ * @tmpl: (type filename): Initial template directory name, last 6 characters will be replaced
+ * @mode: permissions with which to create the temporary directory
+ * @out_tmpdir: (out caller-allocates): Initialized tempdir structure
+ * @error: Error
+ *
+ * Somewhat similar to g_mkdtemp_full(), but fd-relative, and returns a
+ * structure that uses autocleanups.  Note that the supplied @dfd lifetime
+ * must match or exceed that of @out_tmpdir in order to remove the directory.
+ */
+gboolean
+glnx_mkdtempat (int dfd, const char *tmpl, int mode,
+                GLnxTmpDir *out_tmpdir, GError **error)
+{
+  g_return_val_if_fail (tmpl != NULL, FALSE);
+  g_return_val_if_fail (out_tmpdir != NULL, FALSE);
+  g_return_val_if_fail (!out_tmpdir->initialized, FALSE);
+
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  g_autofree char *path = g_strdup (tmpl);
+  for (int count = 0; count < 100; count++)
+    {
+      glnx_gen_temp_name (path);
+
+      /* Ideally we could use openat(O_DIRECTORY | O_CREAT | O_EXCL) here
+       * to create and open the directory atomically, but that’s not supported by
+       * current kernel versions: http://www.openwall.com/lists/oss-security/2014/11/26/14
+       * (Tested on kernel 4.10.10-200.fc25.x86_64). For the moment, accept a
+       * TOCTTOU race here. */
+      if (mkdirat (dfd, path, mode) == -1)
+        {
+          if (errno == EEXIST)
+            continue;
+
+          /* Any other error will apply also to other names we might
+           *  try, and there are 2^32 or so of them, so give up now.
+           */
+          return glnx_throw_errno_prefix (error, "mkdirat");
+        }
+
+      /* And open it */
+      glnx_autofd int ret_dfd = -1;
+      if (!glnx_opendirat (dfd, path, FALSE, &ret_dfd, error))
+        {
+          /* If we fail to open, let's try to clean up */
+          (void)unlinkat (dfd, path, AT_REMOVEDIR);
+          return FALSE;
+        }
+
+      /* Return the initialized directory struct */
+      out_tmpdir->initialized = TRUE;
+      out_tmpdir->src_dfd = dfd; /* referenced; see above docs */
+      out_tmpdir->fd = g_steal_fd (&ret_dfd);
+      out_tmpdir->path = g_steal_pointer (&path);
+      return TRUE;
+    }
+
+  /* Failure */
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+               "glnx_mkdtempat ran out of combinations to try");
+  return FALSE;
+}
+
+/**
+ * glnx_mkdtemp:
+ * @tmpl: (type filename): Source template directory name, last 6 characters will be replaced
+ * @mode: permissions to create the temporary directory with
+ * @out_tmpdir: (out caller-allocates): Return location for tmpdir data
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Similar to glnx_mkdtempat(), but will use g_get_tmp_dir() as the parent
+ * directory to @tmpl.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: UNRELEASED
+ */
+gboolean
+glnx_mkdtemp (const gchar   *tmpl,
+              int      mode,
+              GLnxTmpDir *out_tmpdir,
+              GError **error)
+{
+  g_autofree char *path = g_build_filename (g_get_tmp_dir (), tmpl, NULL);
+  return glnx_mkdtempat (AT_FDCWD, path, mode,
+                         out_tmpdir, error);
+}
+
+static gboolean
+_glnx_tmpdir_free (GLnxTmpDir *tmpd,
+                   gboolean    delete_dir,
+                   GCancellable *cancellable,
+                   GError    **error)
+{
+  /* Support being passed NULL so we work nicely in a GPtrArray */
+  if (!(tmpd && tmpd->initialized))
+    return TRUE;
+  g_assert_cmpint (tmpd->fd, !=, -1);
+  glnx_close_fd (&tmpd->fd);
+  g_assert (tmpd->path);
+  g_assert_cmpint (tmpd->src_dfd, !=, -1);
+  g_autofree char *path = tmpd->path; /* Take ownership */
+  tmpd->initialized = FALSE;
+  if (delete_dir)
+    {
+      if (!glnx_shutil_rm_rf_at (tmpd->src_dfd, path, cancellable, error))
+        return FALSE;
+    }
+  return TRUE;
+}
+
+/**
+ * glnx_tmpdir_delete:
+ * @tmpf: Temporary dir
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Deallocate a tmpdir, closing the fd and recursively deleting the path. This
+ * is normally called indirectly via glnx_tmpdir_cleanup() by the autocleanup
+ * attribute, but you can also invoke this directly.
+ *
+ * If an error occurs while deleting the filesystem path, @tmpf will still have
+ * been deallocated and should not be reused.
+ *
+ * See also `glnx_tmpdir_unset` to avoid deleting the path.
+ */
+gboolean
+glnx_tmpdir_delete (GLnxTmpDir *tmpf, GCancellable *cancellable, GError **error)
+{
+  return _glnx_tmpdir_free (tmpf, TRUE, cancellable, error);
+}
+
+/**
+ * glnx_tmpdir_unset:
+ * @tmpf: Temporary dir
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Deallocate a tmpdir, but do not delete the filesystem path.  See also
+ * `glnx_tmpdir_delete()`.
+ */
+void
+glnx_tmpdir_unset (GLnxTmpDir *tmpf)
+{
+  (void) _glnx_tmpdir_free (tmpf, FALSE, NULL, NULL);
+}

--- a/subprojects/libglnx/glnx-dirfd.h
+++ b/subprojects/libglnx/glnx-dirfd.h
@@ -1,0 +1,139 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-backport-autocleanups.h>
+#include <glnx-macros.h>
+#include <glnx-errors.h>
+#include <limits.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+G_BEGIN_DECLS
+ 
+/**
+ * glnx_dirfd_canonicalize:
+ * @fd: A directory file descriptor
+ *
+ * It's often convenient in programs to use `-1` for "unassigned fd",
+ * and also because gobject-introspection doesn't support `AT_FDCWD`,
+ * libglnx honors `-1` to mean `AT_FDCWD`.  This small inline function
+ * canonicalizes `-1 -> AT_FDCWD`.
+ */
+static inline int
+glnx_dirfd_canonicalize (int fd)
+{
+  if (fd == -1)
+    return AT_FDCWD;
+  return fd;
+}
+
+struct GLnxDirFdIterator {
+  gboolean initialized;
+  int fd;
+  gpointer padding_data[4];
+};
+
+typedef struct GLnxDirFdIterator GLnxDirFdIterator;
+gboolean glnx_dirfd_iterator_init_at (int dfd, const char *path,
+                                    gboolean follow,
+                                    GLnxDirFdIterator *dfd_iter, GError **error);
+gboolean glnx_dirfd_iterator_init_take_fd (int *dfd, GLnxDirFdIterator *dfd_iter, GError **error);
+gboolean glnx_dirfd_iterator_next_dent (GLnxDirFdIterator  *dfd_iter,
+                                        struct dirent     **out_dent,
+                                        GCancellable       *cancellable,
+                                        GError            **error);
+gboolean glnx_dirfd_iterator_next_dent_ensure_dtype (GLnxDirFdIterator  *dfd_iter,
+                                                     struct dirent     **out_dent,
+                                                     GCancellable       *cancellable,
+                                                     GError            **error);
+void glnx_dirfd_iterator_rewind (GLnxDirFdIterator  *dfd_iter);
+void glnx_dirfd_iterator_clear (GLnxDirFdIterator *dfd_iter);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxDirFdIterator, glnx_dirfd_iterator_clear)
+
+int glnx_opendirat_with_errno (int           dfd,
+                               const char   *path,
+                               gboolean      follow);
+
+gboolean glnx_opendirat (int             dfd,
+                         const char     *path,
+                         gboolean        follow,
+                         int            *out_fd,
+                         GError        **error);
+
+char *glnx_fdrel_abspath (int         dfd,
+                          const char *path);
+
+void glnx_gen_temp_name (gchar *tmpl);
+
+/**
+ * glnx_ensure_dir:
+ * @dfd: directory fd
+ * @path: Directory path
+ * @mode: Mode
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Wrapper around mkdirat() which adds #GError support, ensures that
+ * it retries on %EINTR, and also ignores `EEXIST`.
+ *
+ * See also `glnx_shutil_mkdir_p_at()` for recursive handling.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ */
+static inline gboolean
+glnx_ensure_dir (int           dfd,
+                 const char   *path,
+                 mode_t        mode,
+                 GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (mkdirat (dfd, path, mode)) != 0)
+    {
+      if (G_UNLIKELY (errno != EEXIST))
+        return glnx_throw_errno_prefix (error, "mkdirat(%s)", path);
+    }
+  return TRUE;
+}
+
+typedef struct {
+  gboolean initialized;
+  int src_dfd;
+  int fd;
+  char *path;
+} GLnxTmpDir;
+gboolean glnx_tmpdir_delete (GLnxTmpDir *tmpf, GCancellable *cancellable, GError **error);
+void glnx_tmpdir_unset (GLnxTmpDir *tmpf);
+static inline void
+glnx_tmpdir_cleanup (GLnxTmpDir *tmpf)
+{
+  (void)glnx_tmpdir_delete (tmpf, NULL, NULL);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpDir, glnx_tmpdir_cleanup)
+
+gboolean glnx_mkdtempat (int dfd, const char *tmpl, int mode,
+                         GLnxTmpDir *out_tmpdir, GError **error);
+
+gboolean glnx_mkdtemp (const char *tmpl, int      mode,
+                       GLnxTmpDir *out_tmpdir, GError **error);
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-errors.c
+++ b/subprojects/libglnx/glnx-errors.c
@@ -1,0 +1,132 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <glnx-backport-autocleanups.h>
+#include <glnx-errors.h>
+
+/* Set @error with G_IO_ERROR/G_IO_ERROR_FAILED.
+ *
+ * This function returns %FALSE so it can be used conveniently in a single
+ * statement:
+ *
+ * ```
+ *   if (strcmp (foo, "somevalue") != 0)
+ *     return glnx_throw (error, "key must be somevalue, not '%s'", foo);
+ * ```
+ */
+gboolean
+glnx_throw (GError    **error,
+            const char *fmt,
+            ...)
+{
+  if (error == NULL)
+    return FALSE;
+
+  va_list args;
+  va_start (args, fmt);
+  GError *new = g_error_new_valist (G_IO_ERROR, G_IO_ERROR_FAILED, fmt, args);
+  va_end (args);
+  g_propagate_error (error, g_steal_pointer (&new));
+  return FALSE;
+}
+
+void
+glnx_real_set_prefix_error_va (GError     *error,
+                               const char *format,
+                               va_list     args)
+{
+  if (error == NULL)
+    return;
+
+  g_autofree char *old_msg = g_steal_pointer (&error->message);
+  g_autoptr(GString) buf = g_string_new ("");
+  g_string_append_vprintf (buf, format, args);
+  g_string_append (buf, ": ");
+  g_string_append (buf, old_msg);
+  error->message = g_string_free (g_steal_pointer (&buf), FALSE);
+}
+
+/* Prepend to @error's message by `$prefix: ` where `$prefix` is computed via
+ * printf @fmt. Returns %FALSE so it can be used conveniently in a single
+ * statement:
+ *
+ * ```
+ *   if (!function_that_fails (s, error))
+ *     return glnx_throw_prefix (error, "while handling '%s'", s);
+ * ```
+ * */
+gboolean
+glnx_prefix_error (GError    **error,
+                   const char *fmt,
+                   ...)
+{
+  if (error == NULL)
+    return FALSE;
+
+  va_list args;
+  va_start (args, fmt);
+  glnx_real_set_prefix_error_va (*error, fmt, args);
+  va_end (args);
+  return FALSE;
+}
+
+void
+glnx_real_set_prefix_error_from_errno_va (GError     **error,
+                                          gint         errsv,
+                                          const char  *format,
+                                          va_list      args)
+{
+  if (!error)
+    return;
+
+  g_set_error_literal (error,
+                       G_IO_ERROR,
+                       g_io_error_from_errno (errsv),
+                       g_strerror (errsv));
+  glnx_real_set_prefix_error_va (*error, format, args);
+}
+
+/* Set @error using the value of `$prefix: g_strerror (errno)` where `$prefix`
+ * is computed via printf @fmt.
+ *
+ * This function returns %FALSE so it can be used conveniently in a single
+ * statement:
+ *
+ * ```
+ *   return glnx_throw_errno_prefix (error, "unlinking %s", pathname);
+ * ```
+ */
+gboolean
+glnx_throw_errno_prefix (GError    **error,
+                         const char *fmt,
+                         ...)
+{
+  int errsv = errno;
+  va_list args;
+  va_start (args, fmt);
+  glnx_real_set_prefix_error_from_errno_va (error, errsv, fmt, args);
+  va_end (args);
+  /* See comment in glnx_throw_errno() about preserving errno */
+  errno = errsv;
+  return FALSE;
+}

--- a/subprojects/libglnx/glnx-errors.h
+++ b/subprojects/libglnx/glnx-errors.h
@@ -1,0 +1,135 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-backport-autocleanups.h>
+#include <errno.h>
+
+G_BEGIN_DECLS
+
+gboolean glnx_throw (GError **error, const char *fmt, ...) G_GNUC_PRINTF (2,3);
+
+/* Like `glnx_throw ()`, but returns %NULL. */
+#define glnx_null_throw(error, args...) \
+  ({glnx_throw (error, args); NULL;})
+
+/* Implementation detail of glnx_throw_prefix() */
+void glnx_real_set_prefix_error_va (GError     *error,
+                                    const char *format,
+                                    va_list     args) G_GNUC_PRINTF (2,0);
+
+gboolean glnx_prefix_error (GError **error, const char *fmt, ...) G_GNUC_PRINTF (2,3);
+
+/* Like `glnx_prefix_error ()`, but returns %NULL. */
+#define glnx_prefix_error_null(error, args...) \
+  ({glnx_prefix_error (error, args); NULL;})
+
+/**
+ * GLNX_AUTO_PREFIX_ERROR:
+ *
+ * An autocleanup-based macro to automatically call `g_prefix_error()` (also with a colon+space `: `)
+ * when it goes out of scope.  This is useful when one wants error strings built up by the callee
+ * function, not all callers.
+ *
+ * ```
+ * gboolean start_http_request (..., GError **error)
+ * {
+ *   GLNX_AUTO_PREFIX_ERROR ("HTTP request", error)
+ *
+ *   if (!libhttp_request_start (..., error))
+ *     return FALSE;
+ *   ...
+ *   return TRUE;
+ * ```
+ */
+typedef struct {
+  const char *prefix;
+  GError **error;
+} GLnxAutoErrorPrefix;
+static inline void
+glnx_cleanup_auto_prefix_error (GLnxAutoErrorPrefix *prefix)
+{
+  if (prefix->error && *(prefix->error))
+    g_prefix_error (prefix->error, "%s: ", prefix->prefix);
+}
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxAutoErrorPrefix, glnx_cleanup_auto_prefix_error)
+#define GLNX_AUTO_PREFIX_ERROR(text, error) \
+  G_GNUC_UNUSED g_auto(GLnxAutoErrorPrefix) _GLNX_MAKE_ANONYMOUS(_glnxautoprefixerror_) = { text, error }
+
+/* Set @error using the value of `g_strerror (errno)`.
+ *
+ * This function returns %FALSE so it can be used conveniently in a single
+ * statement:
+ *
+ * ```
+ *   if (unlinkat (fd, somepathname) < 0)
+ *     return glnx_throw_errno (error);
+ * ```
+ */
+static inline gboolean
+glnx_throw_errno (GError **error)
+{
+  /* Save the value of errno, in case one of the
+   * intermediate function calls happens to set it.
+   */
+  int errsv = errno;
+  g_set_error_literal (error, G_IO_ERROR,
+                       g_io_error_from_errno (errsv),
+                       g_strerror (errsv));
+  /* We also restore the value of errno, since that's
+   * what was done in a long-ago libgsystem commit
+   * https://git.gnome.org/browse/libgsystem/commit/?id=ed106741f7a0596dc8b960b31fdae671d31d666d
+   * but I certainly can't remember now why I did that.
+   */
+  errno = errsv;
+  return FALSE;
+}
+
+/* Like glnx_throw_errno(), but yields a NULL pointer. */
+#define glnx_null_throw_errno(error) \
+  ({glnx_throw_errno (error); NULL;})
+
+/* Implementation detail of glnx_throw_errno_prefix() */
+void glnx_real_set_prefix_error_from_errno_va (GError     **error,
+                                               gint         errsv,
+                                               const char  *format,
+                                               va_list      args) G_GNUC_PRINTF (3,0);
+
+gboolean glnx_throw_errno_prefix (GError **error, const char *fmt, ...) G_GNUC_PRINTF (2,3);
+
+/* Like glnx_throw_errno_prefix(), but yields a NULL pointer. */
+#define glnx_null_throw_errno_prefix(error, args...) \
+  ({glnx_throw_errno_prefix (error, args); NULL;})
+
+/* BEGIN LEGACY APIS */
+
+#define glnx_set_error_from_errno(error)                \
+  do {                                                  \
+    glnx_throw_errno (error);                           \
+  } while (0);
+
+#define glnx_set_prefix_error_from_errno(error, format, args...)  \
+  do {                                                            \
+    glnx_throw_errno_prefix (error, format, args);                \
+  } while (0);
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-fdio.c
+++ b/subprojects/libglnx/glnx-fdio.c
@@ -1,0 +1,1207 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * Portions derived from systemd:
+ *  Copyright 2010 Lennart Poettering
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/ioctl.h>
+#include <sys/sendfile.h>
+#include <errno.h>
+
+#include <glnx-fdio.h>
+#include <glnx-dirfd.h>
+#include <glnx-errors.h>
+#include <glnx-xattrs.h>
+#include <glnx-backport-autoptr.h>
+#include <glnx-backports.h>
+#include <glnx-local-alloc.h>
+#include <glnx-missing.h>
+
+/* The standardized version of BTRFS_IOC_CLONE */
+#ifndef FICLONE
+#define FICLONE _IOW(0x94, 9, int)
+#endif
+
+/* Returns the number of chars needed to format variables of the
+ * specified type as a decimal string. Adds in extra space for a
+ * negative '-' prefix (hence works correctly on signed
+ * types). Includes space for the trailing NUL. */
+#define DECIMAL_STR_MAX(type)                                           \
+        (2+(sizeof(type) <= 1 ? 3 :                                     \
+            sizeof(type) <= 2 ? 5 :                                     \
+            sizeof(type) <= 4 ? 10 :                                    \
+            sizeof(type) <= 8 ? 20 : sizeof(int[-2*(sizeof(type) > 8)])))
+
+gboolean
+glnx_stdio_file_flush (FILE *f, GError **error)
+{
+  if (fflush (f) != 0)
+    return glnx_throw_errno_prefix (error, "fflush");
+  if (ferror (f) != 0)
+    return glnx_throw_errno_prefix (error, "ferror");
+  return TRUE;
+}
+
+/* An implementation of renameat2(..., RENAME_NOREPLACE)
+ * with fallback to a non-atomic version.
+ */
+int
+glnx_renameat2_noreplace (int olddirfd, const char *oldpath,
+                          int newdirfd, const char *newpath)
+{
+#ifndef ENABLE_WRPSEUDO_COMPAT
+  if (renameat2 (olddirfd, oldpath, newdirfd, newpath, RENAME_NOREPLACE) < 0)
+    {
+      if (G_IN_SET(errno, EINVAL, ENOSYS))
+        {
+          /* Fall through */
+        }
+      else
+        {
+          return -1;
+        }
+    }
+  else
+    return TRUE;
+#endif
+
+  if (linkat (olddirfd, oldpath, newdirfd, newpath, 0) < 0)
+    return -1;
+
+  if (unlinkat (olddirfd, oldpath, 0) < 0)
+    return -1;
+
+  return 0;
+}
+
+static gboolean
+rename_file_noreplace_at (int olddirfd, const char *oldpath,
+                          int newdirfd, const char *newpath,
+                          gboolean ignore_eexist,
+                          GError **error)
+{
+  if (glnx_renameat2_noreplace (olddirfd, oldpath,
+                                newdirfd, newpath) < 0)
+    {
+      if (errno == EEXIST && ignore_eexist)
+        {
+          (void) unlinkat (olddirfd, oldpath, 0);
+          return TRUE;
+        }
+      else
+        return glnx_throw_errno_prefix (error, "renameat");
+    }
+  return TRUE;
+}
+
+/* An implementation of renameat2(..., RENAME_EXCHANGE)
+ * with fallback to a non-atomic version.
+ */
+int
+glnx_renameat2_exchange (int olddirfd, const char *oldpath,
+                         int newdirfd, const char *newpath)
+{
+#ifndef ENABLE_WRPSEUDO_COMPAT
+  if (renameat2 (olddirfd, oldpath, newdirfd, newpath, RENAME_EXCHANGE) == 0)
+    return 0;
+  else
+    {
+      if (G_IN_SET(errno, ENOSYS, EINVAL))
+        {
+          /* Fall through */
+        }
+      else
+        {
+          return -1;
+        }
+    }
+#endif
+
+  /* Fallback */
+  { char *old_tmp_name_buf = glnx_strjoina (oldpath, ".XXXXXX");
+    /* This obviously isn't race-free, but doing better gets tricky, since if
+     * we're here the kernel isn't likely to support RENAME_NOREPLACE either.
+     * Anyways, upgrade the kernel. Failing that, avoid use of this function in
+     * shared subdirectories like /tmp.
+     */
+    glnx_gen_temp_name (old_tmp_name_buf);
+    const char *old_tmp_name = old_tmp_name_buf;
+
+    /* Move old out of the way */
+    if (renameat (olddirfd, oldpath, olddirfd, old_tmp_name) < 0)
+      return -1;
+    /* Now move new into its place */
+    if (renameat (newdirfd, newpath, olddirfd, oldpath) < 0)
+      return -1;
+    /* And finally old(tmp) into new */
+    if (renameat (olddirfd, old_tmp_name, newdirfd, newpath) < 0)
+      return -1;
+  }
+  return 0;
+}
+
+/* Deallocate a tmpfile, closing the fd and deleting the path, if any. This is
+ * normally called by default by the autocleanup attribute, but you can also
+ * invoke this directly.
+ */
+void
+glnx_tmpfile_clear (GLnxTmpfile *tmpf)
+{
+  /* Support being passed NULL so we work nicely in a GPtrArray */
+  if (!tmpf)
+    return;
+  if (!tmpf->initialized)
+    return;
+  glnx_close_fd (&tmpf->fd);
+  /* If ->path is set, we're likely aborting due to an error. Clean it up */
+  if (tmpf->path)
+    {
+      (void) unlinkat (tmpf->src_dfd, tmpf->path, 0);
+      g_free (tmpf->path);
+    }
+  tmpf->initialized = FALSE;
+}
+
+static gboolean
+open_tmpfile_core (int dfd, const char *subpath,
+                   int flags,
+                   GLnxTmpfile *out_tmpf,
+                   GError **error)
+{
+  /* Picked this to match mkstemp() */
+  const guint mode = 0600;
+
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  /* Creates a temporary file, that shall be renamed to "target"
+   * later. If possible, this uses O_TMPFILE – in which case
+   * "ret_path" will be returned as NULL. If not possible a the
+   * tempoary path name used is returned in "ret_path". Use
+   * link_tmpfile() below to rename the result after writing the file
+   * in full. */
+#if defined(O_TMPFILE) && !defined(DISABLE_OTMPFILE) && !defined(ENABLE_WRPSEUDO_COMPAT)
+  {
+    glnx_autofd int fd = openat (dfd, subpath, O_TMPFILE|flags, mode);
+    if (fd == -1 && !(G_IN_SET(errno, ENOSYS, EISDIR, EOPNOTSUPP)))
+      return glnx_throw_errno_prefix (error, "open(O_TMPFILE)");
+    if (fd != -1)
+      {
+        /* Workaround for https://sourceware.org/bugzilla/show_bug.cgi?id=17523
+         * See also https://github.com/ostreedev/ostree/issues/991
+         */
+        if (fchmod (fd, mode) < 0)
+          return glnx_throw_errno_prefix (error, "fchmod");
+        out_tmpf->initialized = TRUE;
+        out_tmpf->src_dfd = dfd; /* Copied; caller must keep open */
+        out_tmpf->fd = g_steal_fd (&fd);
+        out_tmpf->path = NULL;
+        return TRUE;
+      }
+  }
+  /* Fallthrough */
+#endif
+
+  const guint count_max = 100;
+  { g_autofree char *tmp = g_strconcat (subpath, "/tmp.XXXXXX", NULL);
+
+    for (guint count = 0; count < count_max; count++)
+      {
+        glnx_gen_temp_name (tmp);
+
+        glnx_autofd int fd = openat (dfd, tmp, O_CREAT|O_EXCL|O_NOFOLLOW|O_NOCTTY|flags, mode);
+        if (fd < 0)
+          {
+            if (errno == EEXIST)
+              continue;
+            else
+              return glnx_throw_errno_prefix (error, "Creating temp file");
+          }
+        else
+          {
+            out_tmpf->initialized = TRUE;
+            out_tmpf->src_dfd = dfd;  /* Copied; caller must keep open */
+            out_tmpf->fd = g_steal_fd (&fd);
+            out_tmpf->path = g_steal_pointer (&tmp);
+            return TRUE;
+          }
+      }
+  }
+  g_set_error (error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+               "Exhausted %u attempts to create temporary file", count_max);
+  return FALSE;
+}
+
+/* Allocate a temporary file, using Linux O_TMPFILE if available. The file mode
+ * will be 0600.
+ *
+ * The result will be stored in @out_tmpf, which is caller allocated
+ * so you can store it on the stack in common scenarios.
+ *
+ * The directory fd @dfd must live at least as long as the output @out_tmpf.
+ */
+gboolean
+glnx_open_tmpfile_linkable_at (int dfd,
+                               const char *subpath,
+                               int flags,
+                               GLnxTmpfile *out_tmpf,
+                               GError **error)
+{
+  /* Don't allow O_EXCL, as that has a special meaning for O_TMPFILE;
+   * it's used for glnx_open_anonymous_tmpfile().
+   */
+  g_return_val_if_fail ((flags & O_EXCL) == 0, FALSE);
+
+  return open_tmpfile_core (dfd, subpath, flags, out_tmpf, error);
+}
+
+
+/* A variant of `glnx_open_tmpfile_linkable_at()` which doesn't support linking.
+ * Useful for true temporary storage. The fd will be allocated in the specified
+ * directory.
+ */
+gboolean
+glnx_open_anonymous_tmpfile_full (int          flags,
+                                  const char  *dir,
+                                  GLnxTmpfile *out_tmpf,
+                                  GError     **error)
+{
+  /* Add in O_EXCL */
+  if (!open_tmpfile_core (AT_FDCWD, dir, flags | O_EXCL, out_tmpf, error))
+    return FALSE;
+  if (out_tmpf->path)
+    {
+      (void) unlinkat (out_tmpf->src_dfd, out_tmpf->path, 0);
+      g_clear_pointer (&out_tmpf->path, g_free);
+    }
+  out_tmpf->anonymous = TRUE;
+  out_tmpf->src_dfd = -1;
+  return TRUE;
+}
+
+/* A variant of `glnx_open_tmpfile_linkable_at()` which doesn't support linking.
+ * Useful for true temporary storage. The fd will be allocated in `$TMPDIR` if
+ * set or `/var/tmp` otherwise.
+ *
+ * If you need the file on a specific filesystem use glnx_open_anonymous_tmpfile_full()
+ * which lets you pass a directory.
+ */
+gboolean
+glnx_open_anonymous_tmpfile (int          flags,
+                             GLnxTmpfile *out_tmpf,
+                             GError     **error)
+{
+  return glnx_open_anonymous_tmpfile_full (flags,
+                                           getenv("TMPDIR") ?: "/var/tmp",
+                                           out_tmpf,
+                                           error);
+}
+
+/* Use this after calling glnx_open_tmpfile_linkable_at() to give
+ * the file its final name (link into place).
+ */
+gboolean
+glnx_link_tmpfile_at (GLnxTmpfile *tmpf,
+                      GLnxLinkTmpfileReplaceMode mode,
+                      int target_dfd,
+                      const char *target,
+                      GError **error)
+{
+  const gboolean replace = (mode == GLNX_LINK_TMPFILE_REPLACE);
+  const gboolean ignore_eexist = (mode == GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST);
+
+  g_return_val_if_fail (!tmpf->anonymous, FALSE);
+  g_return_val_if_fail (tmpf->fd >= 0, FALSE);
+  g_return_val_if_fail (tmpf->src_dfd == AT_FDCWD || tmpf->src_dfd >= 0, FALSE);
+
+  /* Unlike the original systemd code, this function also supports
+   * replacing existing files.
+   */
+
+  /* We have `tmpfile_path` for old systems without O_TMPFILE. */
+  if (tmpf->path)
+    {
+      if (replace)
+        {
+          /* We have a regular tempfile, we're overwriting - this is a
+           * simple renameat().
+           */
+          if (renameat (tmpf->src_dfd, tmpf->path, target_dfd, target) < 0)
+            return glnx_throw_errno_prefix (error, "renameat");
+        }
+      else
+        {
+          /* We need to use renameat2(..., NOREPLACE) or emulate it */
+          if (!rename_file_noreplace_at (tmpf->src_dfd, tmpf->path, target_dfd, target,
+                                         ignore_eexist,
+                                         error))
+            return FALSE;
+        }
+      /* Now, clear the pointer so we don't try to unlink it */
+      g_clear_pointer (&tmpf->path, g_free);
+    }
+  else
+    {
+      /* This case we have O_TMPFILE, so our reference to it is via /proc/self/fd */
+      char proc_fd_path[strlen("/proc/self/fd/") + DECIMAL_STR_MAX(tmpf->fd) + 1];
+      snprintf (proc_fd_path, sizeof (proc_fd_path), "/proc/self/fd/%i", tmpf->fd);
+
+      if (replace)
+        {
+          /* In this case, we had our temp file atomically hidden, but now
+           * we need to make it visible in the FS so we can do a rename.
+           * Ideally, linkat() would gain AT_REPLACE or so.
+           */
+          /* TODO - avoid double alloca, we can just alloca a copy of
+           * the pathname plus space for tmp.XXXXX */
+          char *dnbuf = strdupa (target);
+          const char *dn = dirname (dnbuf);
+          char *tmpname_buf = glnx_strjoina (dn, "/tmp.XXXXXX");
+
+          const guint count_max = 100;
+          guint count;
+          for (count = 0; count < count_max; count++)
+            {
+              glnx_gen_temp_name (tmpname_buf);
+
+              if (linkat (AT_FDCWD, proc_fd_path, target_dfd, tmpname_buf, AT_SYMLINK_FOLLOW) < 0)
+                {
+                  if (errno == EEXIST)
+                    continue;
+                  else
+                    return glnx_throw_errno_prefix (error, "linkat");
+                }
+              else
+                break;
+            }
+          if (count == count_max)
+            {
+              g_set_error (error, G_IO_ERROR, G_IO_ERROR_EXISTS,
+               "Exhausted %u attempts to create temporary file", count);
+              return FALSE;
+            }
+          if (!glnx_renameat (target_dfd, tmpname_buf, target_dfd, target, error))
+            {
+              /* This is currently the only case where we need to have
+               * a cleanup unlinkat() still with O_TMPFILE.
+               */
+              (void) unlinkat (target_dfd, tmpname_buf, 0);
+              return FALSE;
+            }
+        }
+      else
+        {
+          if (linkat (AT_FDCWD, proc_fd_path, target_dfd, target, AT_SYMLINK_FOLLOW) < 0)
+            {
+              if (errno == EEXIST && mode == GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST)
+                ;
+              else
+                return glnx_throw_errno_prefix (error, "linkat");
+            }
+        }
+
+    }
+  return TRUE;
+}
+
+/* glnx_tmpfile_reopen_rdonly:
+ * @tmpf: tmpfile
+ * @error: Error
+ *
+ * Give up write access to the file descriptior.  One use
+ * case for this is fs-verity, which requires a read-only fd.
+ * It could also be useful to allocate an anonymous tmpfile
+ * write some sort of caching/indexing data to it, then reopen it
+ * read-only thereafter.
+ **/
+gboolean
+glnx_tmpfile_reopen_rdonly (GLnxTmpfile *tmpf,
+                            GError **error)
+{
+  g_return_val_if_fail (tmpf->fd >= 0, FALSE);
+  g_return_val_if_fail (tmpf->src_dfd == AT_FDCWD || tmpf->src_dfd >= 0, FALSE);
+
+  glnx_fd_close int rdonly_fd = -1;
+
+  if (tmpf->path)
+    {
+      if (!glnx_openat_rdonly (tmpf->src_dfd, tmpf->path, FALSE, &rdonly_fd, error))
+        return FALSE;
+    }
+  else
+    {
+      /* This case we have O_TMPFILE, so our reference to it is via /proc/self/fd */
+      char proc_fd_path[strlen("/proc/self/fd/") + DECIMAL_STR_MAX(tmpf->fd) + 1];
+      snprintf (proc_fd_path, sizeof (proc_fd_path), "/proc/self/fd/%i", tmpf->fd);
+
+      if (!glnx_openat_rdonly (AT_FDCWD, proc_fd_path, TRUE, &rdonly_fd, error))
+        return FALSE;
+    }
+
+  glnx_close_fd (&tmpf->fd);
+  tmpf->fd = g_steal_fd (&rdonly_fd);
+  return TRUE;
+}
+
+/**
+ * glnx_openat_rdonly:
+ * @dfd: File descriptor for origin directory
+ * @path: Pathname, relative to @dfd
+ * @follow: Whether or not to follow symbolic links in the final component
+ * @out_fd: (out): File descriptor
+ * @error: Error
+ *
+ * Use openat() to open a file, with flags `O_RDONLY | O_CLOEXEC | O_NOCTTY`.
+ * Like the other libglnx wrappers, will use `TEMP_FAILURE_RETRY` and
+ * also includes @path in @error in case of failure.
+ */
+gboolean
+glnx_openat_rdonly (int             dfd,
+                    const char     *path,
+                    gboolean        follow,
+                    int            *out_fd,
+                    GError        **error)
+{
+  int flags = O_RDONLY | O_CLOEXEC | O_NOCTTY;
+  if (!follow)
+    flags |= O_NOFOLLOW;
+  int fd = TEMP_FAILURE_RETRY (openat (dfd, path, flags));
+  if (fd == -1)
+    return glnx_throw_errno_prefix (error, "openat(%s)", path);
+  *out_fd = fd;
+  return TRUE;
+}
+
+static guint8*
+glnx_fd_readall_malloc (int               fd,
+                        gsize            *out_len,
+                        gboolean          nul_terminate,
+                        GCancellable     *cancellable,
+                        GError          **error)
+{
+  const guint maxreadlen = 4096;
+
+  struct stat stbuf;
+  if (!glnx_fstat (fd, &stbuf, error))
+    return FALSE;
+
+  gsize buf_allocated;
+  if (S_ISREG (stbuf.st_mode) && stbuf.st_size > 0)
+    buf_allocated = stbuf.st_size;
+  else
+    buf_allocated = 16;
+
+  g_autofree guint8* buf = g_malloc (buf_allocated);
+
+  gsize buf_size = 0;
+  while (TRUE)
+    {
+      gsize readlen = MIN (buf_allocated - buf_size, maxreadlen);
+
+      if (g_cancellable_set_error_if_cancelled (cancellable, error))
+        return FALSE;
+
+      gssize bytes_read;
+      do
+        bytes_read = read (fd, buf + buf_size, readlen);
+      while (G_UNLIKELY (bytes_read == -1 && errno == EINTR));
+      if (G_UNLIKELY (bytes_read == -1))
+        return glnx_null_throw_errno (error);
+      if (bytes_read == 0)
+        break;
+
+      buf_size += bytes_read;
+      if (buf_allocated - buf_size < maxreadlen)
+        buf = g_realloc (buf, buf_allocated *= 2);
+    }
+
+  if (nul_terminate)
+    {
+      if (buf_allocated - buf_size == 0)
+        buf = g_realloc (buf, buf_allocated + 1);
+      buf[buf_size] = '\0';
+    }
+
+  *out_len = buf_size;
+  return g_steal_pointer (&buf);
+}
+
+/**
+ * glnx_fd_readall_bytes:
+ * @fd: A file descriptor
+ * @cancellable: Cancellable:
+ * @error: Error
+ *
+ * Read all data from file descriptor @fd into a #GBytes.  It's
+ * recommended to only use this for small files.
+ *
+ * Returns: (transfer full): A newly allocated #GBytes
+ */
+GBytes *
+glnx_fd_readall_bytes (int               fd,
+                       GCancellable     *cancellable,
+                       GError          **error)
+{
+  gsize len;
+  guint8 *buf = glnx_fd_readall_malloc (fd, &len, FALSE, cancellable, error);
+  if (!buf)
+    return NULL;
+  return g_bytes_new_take (buf, len);
+}
+
+/**
+ * glnx_fd_readall_utf8:
+ * @fd: A file descriptor
+ * @out_len: (out): Returned length
+ * @cancellable: Cancellable:
+ * @error: Error
+ *
+ * Read all data from file descriptor @fd, validating
+ * the result as UTF-8.
+ *
+ * Returns: (transfer full): A string validated as UTF-8, or %NULL on error.
+ */
+char *
+glnx_fd_readall_utf8 (int               fd,
+                      gsize            *out_len,
+                      GCancellable     *cancellable,
+                      GError          **error)
+{
+  gsize len;
+  g_autofree guint8 *buf = glnx_fd_readall_malloc (fd, &len, TRUE, cancellable, error);
+  if (!buf)
+    return FALSE;
+
+  if (!g_utf8_validate ((char*)buf, len, NULL))
+    {
+      g_set_error (error,
+                   G_IO_ERROR,
+                   G_IO_ERROR_INVALID_DATA,
+                   "Invalid UTF-8");
+      return FALSE;
+    }
+
+  if (out_len)
+    *out_len = len;
+  return (char*)g_steal_pointer (&buf);
+}
+
+/**
+ * glnx_file_get_contents_utf8_at:
+ * @dfd: Directory file descriptor
+ * @subpath: Path relative to @dfd
+ * @out_len: (out) (allow-none): Optional length
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Read the entire contents of the file referred
+ * to by @dfd and @subpath, validate the result as UTF-8.
+ * The length is optionally stored in @out_len.
+ *
+ * Returns: (transfer full): UTF-8 validated text, or %NULL on error
+ */
+char *
+glnx_file_get_contents_utf8_at (int                   dfd,
+                                const char           *subpath,
+                                gsize                *out_len,
+                                GCancellable         *cancellable,
+                                GError              **error)
+{
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  glnx_autofd int fd = -1;
+  if (!glnx_openat_rdonly (dfd, subpath, TRUE, &fd, error))
+    return NULL;
+
+  gsize len;
+  g_autofree char *buf = glnx_fd_readall_utf8 (fd, &len, cancellable, error);
+  if (G_UNLIKELY(!buf))
+    return FALSE;
+
+  if (out_len)
+    *out_len = len;
+  return g_steal_pointer (&buf);
+}
+
+/**
+ * glnx_readlinkat_malloc:
+ * @dfd: Directory file descriptor
+ * @subpath: Subpath
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Read the value of a symlink into a dynamically
+ * allocated buffer.
+ */
+char *
+glnx_readlinkat_malloc (int            dfd,
+                        const char    *subpath,
+                        G_GNUC_UNUSED GCancellable *cancellable,
+                        GError       **error)
+{
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  size_t l = 100;
+  for (;;)
+    {
+      g_autofree char *c = g_malloc (l);
+      ssize_t n = TEMP_FAILURE_RETRY (readlinkat (dfd, subpath, c, l-1));
+      if (n < 0)
+        return glnx_null_throw_errno_prefix (error, "readlinkat");
+
+      if ((size_t) n < l-1)
+        {
+          c[n] = 0;
+          return g_steal_pointer (&c);
+        }
+
+      l *= 2;
+    }
+
+  g_assert_not_reached ();
+}
+
+static gboolean
+copy_symlink_at (int                   src_dfd,
+                 const char           *src_subpath,
+                 const struct stat    *src_stbuf,
+                 int                   dest_dfd,
+                 const char           *dest_subpath,
+                 GLnxFileCopyFlags     copyflags,
+                 GCancellable         *cancellable,
+                 GError              **error)
+{
+  g_autofree char *buf = glnx_readlinkat_malloc (src_dfd, src_subpath, cancellable, error);
+  if (!buf)
+    return FALSE;
+
+  if (TEMP_FAILURE_RETRY (symlinkat (buf, dest_dfd, dest_subpath)) != 0)
+    return glnx_throw_errno_prefix (error, "symlinkat");
+
+  if (!(copyflags & GLNX_FILE_COPY_NOXATTRS))
+    {
+      g_autoptr(GVariant) xattrs = NULL;
+
+      if (!glnx_dfd_name_get_all_xattrs (src_dfd, src_subpath, &xattrs,
+                                         cancellable, error))
+        return FALSE;
+
+      if (!glnx_dfd_name_set_all_xattrs (dest_dfd, dest_subpath, xattrs,
+                                         cancellable, error))
+        return FALSE;
+    }
+
+  if (TEMP_FAILURE_RETRY (fchownat (dest_dfd, dest_subpath,
+                                    src_stbuf->st_uid, src_stbuf->st_gid,
+                                    AT_SYMLINK_NOFOLLOW)) != 0)
+    return glnx_throw_errno_prefix (error, "fchownat");
+
+  return TRUE;
+}
+
+#define COPY_BUFFER_SIZE (16*1024)
+
+/* Most of the code below is from systemd, but has been reindented to GNU style,
+ * and changed to use POSIX error conventions (return -1, set errno) to more
+ * conveniently fit in with the rest of libglnx.
+ */
+
+/* Like write(), but loop until @nbytes are written, or an error
+ * occurs.
+ *
+ * On error, -1 is returned an @errno is set.  NOTE: This is an
+ * API change from previous versions of this function.
+ */
+int
+glnx_loop_write(int fd, const void *buf, size_t nbytes)
+{
+  g_return_val_if_fail (fd >= 0, -1);
+  g_return_val_if_fail (buf, -1);
+
+  errno = 0;
+
+  const uint8_t *p = buf;
+  while (nbytes > 0)
+    {
+      ssize_t k = write(fd, p, nbytes);
+      if (k < 0)
+        {
+          if (errno == EINTR)
+            continue;
+
+          return -1;
+        }
+
+      if (k == 0) /* Can't really happen */
+        {
+          errno = EIO;
+          return -1;
+        }
+
+      p += k;
+      nbytes -= k;
+    }
+
+  return 0;
+}
+
+/* Read from @fdf until EOF, writing to @fdt. If max_bytes is -1, a full-file
+ * clone will be attempted. Otherwise Linux copy_file_range(), sendfile()
+ * syscall will be attempted.  If none of those work, this function will do a
+ * plain read()/write() loop.
+ *
+ * The file descriptor @fdf must refer to a regular file.
+ *
+ * If provided, @max_bytes specifies the maximum number of bytes to read from @fdf.
+ * On error, this function returns `-1` and @errno will be set.
+ */
+int
+glnx_regfile_copy_bytes (int fdf, int fdt, off_t max_bytes)
+{
+  /* Last updates from systemd as of commit 6bda23dd6aaba50cf8e3e6024248cf736cc443ca */
+  static int have_cfr = -1; /* -1 means unknown */
+  bool try_cfr = have_cfr != 0;
+  static int have_sendfile = -1; /* -1 means unknown */
+  bool try_sendfile = have_sendfile != 0;
+
+  g_return_val_if_fail (fdf >= 0, -1);
+  g_return_val_if_fail (fdt >= 0, -1);
+  g_return_val_if_fail (max_bytes >= -1, -1);
+
+  /* If we've requested to copy the whole range, try a full-file clone first.
+   */
+  if (max_bytes == (off_t) -1 &&
+      lseek (fdf, 0, SEEK_CUR) == 0 &&
+      lseek (fdt, 0, SEEK_CUR) == 0)
+    {
+      if (ioctl (fdt, FICLONE, fdf) == 0)
+        {
+          /* All the other methods advance the fds. Do it here too for consistency. */
+          if (lseek (fdf, 0, SEEK_END) < 0)
+            return -1;
+          if (lseek (fdt, 0, SEEK_END) < 0)
+            return -1;
+
+          return 0;
+        }
+
+      /* Fall through */
+      struct stat stbuf;
+
+      /* Gather the size so we can provide the whole thing at once to
+       * copy_file_range() or sendfile().
+       */
+      if (fstat (fdf, &stbuf) < 0)
+        return -1;
+
+      if (stbuf.st_size > 0)
+        max_bytes = stbuf.st_size;
+    }
+
+  while (TRUE)
+    {
+      ssize_t n;
+
+      /* First, try copy_file_range(). Note this is an inlined version of
+       * try_copy_file_range() from systemd upstream, which works better since
+       * we use POSIX errno style.
+       */
+      if (try_cfr && max_bytes != (off_t) -1)
+        {
+          n = copy_file_range (fdf, NULL, fdt, NULL, max_bytes, 0u);
+          if (n < 0)
+            {
+              if (errno == ENOSYS)
+                {
+                  /* No cfr in kernel, mark as permanently unavailable
+                   * and fall through to sendfile().
+                   */
+                  have_cfr = 0;
+                  try_cfr = false;
+                }
+              else if (G_IN_SET (errno, EXDEV, EINVAL, EOPNOTSUPP))
+                /* We won't try cfr again for this run, but let's be
+                 * conservative and not mark it as available/unavailable until
+                 * we know for sure.
+                 */
+                try_cfr = false;
+              else
+                return -1;
+            }
+          else
+            {
+              /* cfr worked, mark it as available */
+              if (have_cfr == -1)
+                have_cfr = 1;
+
+              if (n == 0) /* EOF */
+                break;
+              else
+                /* Success! */
+                goto next;
+            }
+        }
+
+      /* Next try sendfile(); this version is also changed from systemd upstream
+       * to match the same logic we have for copy_file_range().
+       */
+      if (try_sendfile && max_bytes != (off_t) -1)
+        {
+          n = sendfile (fdt, fdf, NULL, max_bytes);
+          if (n < 0)
+            {
+              if (G_IN_SET (errno, EINVAL, ENOSYS))
+                {
+                  /* No sendfile(), or it doesn't work on regular files.
+                   * Mark it as permanently unavailable, and fall through
+                   * to plain read()/write().
+                   */
+                  have_sendfile = 0;
+                  try_sendfile = false;
+                }
+              else
+                return -1;
+            }
+          else
+            {
+              /* sendfile() worked, mark it as available */
+              if (have_sendfile == -1)
+                have_sendfile = 1;
+
+              if (n == 0) /* EOF */
+                break;
+              else if (n > 0)
+                /* Succcess! */
+                goto next;
+            }
+        }
+
+      /* As a fallback just copy bits by hand */
+      { size_t m = COPY_BUFFER_SIZE;
+        if (max_bytes != (off_t) -1)
+          {
+            if ((off_t) m > max_bytes)
+              m = (size_t) max_bytes;
+          }
+        char buf[m];
+
+        n = TEMP_FAILURE_RETRY (read (fdf, buf, m));
+        if (n < 0)
+          return -1;
+        if (n == 0) /* EOF */
+          break;
+
+        if (glnx_loop_write (fdt, buf, (size_t) n) < 0)
+          return -1;
+      }
+
+    next:
+      if (max_bytes != (off_t) -1)
+        {
+          g_assert_cmpint (max_bytes, >=, n);
+          max_bytes -= n;
+          if (max_bytes == 0)
+            break;
+        }
+    }
+
+  return 0;
+}
+
+/**
+ * glnx_file_copy_at:
+ * @src_dfd: Source directory fd
+ * @src_subpath: Subpath relative to @src_dfd
+ * @src_stbuf: (allow-none): Optional stat buffer for source; if a stat() has already been done
+ * @dest_dfd: Target directory fd
+ * @dest_subpath: Destination name
+ * @copyflags: Flags
+ * @cancellable: cancellable
+ * @error: Error
+ *
+ * Perform a full copy of the regular file or symbolic link from @src_subpath to
+ * @dest_subpath; if @src_subpath is anything other than a regular file or
+ * symbolic link, an error will be returned.
+ *
+ * If the source is a regular file and the destination exists as a symbolic
+ * link, the symbolic link will not be followed; rather the link itself will be
+ * replaced. Related to this: for regular files, when `GLNX_FILE_COPY_OVERWRITE`
+ * is specified, this function always uses `O_TMPFILE` (if available) and does a
+ * rename-into-place rather than `open(O_TRUNC)`.
+ */
+gboolean
+glnx_file_copy_at (int                   src_dfd,
+                   const char           *src_subpath,
+                   const struct stat    *src_stbuf,
+                   int                   dest_dfd,
+                   const char           *dest_subpath,
+                   GLnxFileCopyFlags     copyflags,
+                   GCancellable         *cancellable,
+                   GError              **error)
+{
+  /* Canonicalize dfds */
+  src_dfd = glnx_dirfd_canonicalize (src_dfd);
+  dest_dfd = glnx_dirfd_canonicalize (dest_dfd);
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+  /* Automatically do stat() if no stat buffer was supplied */
+  struct stat local_stbuf;
+  if (!src_stbuf)
+    {
+      if (!glnx_fstatat (src_dfd, src_subpath, &local_stbuf, AT_SYMLINK_NOFOLLOW, error))
+        return FALSE;
+      src_stbuf = &local_stbuf;
+    }
+
+  /* For symlinks, defer entirely to copy_symlink_at() */
+  if (S_ISLNK (src_stbuf->st_mode))
+    {
+      return copy_symlink_at (src_dfd, src_subpath, src_stbuf,
+                              dest_dfd, dest_subpath,
+                              copyflags,
+                              cancellable, error);
+    }
+  else if (!S_ISREG (src_stbuf->st_mode))
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_NOT_SUPPORTED,
+                   "Cannot copy non-regular/non-symlink file: %s", src_subpath);
+      return FALSE;
+    }
+
+  /* Regular file path below here */
+
+  glnx_autofd int src_fd = -1;
+  if (!glnx_openat_rdonly (src_dfd, src_subpath, FALSE, &src_fd, error))
+    return FALSE;
+
+  /* Open a tmpfile for dest. Particularly for AT_FDCWD calls, we really want to
+   * open in the target directory, otherwise we may not be able to link.
+   */
+  g_auto(GLnxTmpfile) tmp_dest = { 0, };
+  { char *dnbuf = strdupa (dest_subpath);
+    const char *dn = dirname (dnbuf);
+    if (!glnx_open_tmpfile_linkable_at (dest_dfd, dn, O_WRONLY | O_CLOEXEC,
+                                        &tmp_dest, error))
+      return FALSE;
+  }
+
+  if (glnx_regfile_copy_bytes (src_fd, tmp_dest.fd, (off_t) -1) < 0)
+    return glnx_throw_errno_prefix (error, "regfile copy");
+
+  if (!(copyflags & GLNX_FILE_COPY_NOCHOWN))
+    {
+      if (fchown (tmp_dest.fd, src_stbuf->st_uid, src_stbuf->st_gid) != 0)
+        return glnx_throw_errno_prefix (error, "fchown");
+    }
+
+  if (!(copyflags & GLNX_FILE_COPY_NOXATTRS))
+    {
+      g_autoptr(GVariant) xattrs = NULL;
+
+      if (!glnx_fd_get_all_xattrs (src_fd, &xattrs,
+                                   cancellable, error))
+        return FALSE;
+
+      if (!glnx_fd_set_all_xattrs (tmp_dest.fd, xattrs,
+                                   cancellable, error))
+        return FALSE;
+    }
+
+  /* Always chmod after setting xattrs, in case the file has mode 0400 or less,
+   * like /etc/shadow.  Linux currently allows write() on non-writable open files
+   * but not fsetxattr().
+   */
+  if (fchmod (tmp_dest.fd, src_stbuf->st_mode & 07777) != 0)
+    return glnx_throw_errno_prefix (error, "fchmod");
+
+  struct timespec ts[2];
+  ts[0] = src_stbuf->st_atim;
+  ts[1] = src_stbuf->st_mtim;
+  (void) futimens (tmp_dest.fd, ts);
+
+  if (copyflags & GLNX_FILE_COPY_DATASYNC)
+    {
+      if (fdatasync (tmp_dest.fd) < 0)
+        return glnx_throw_errno_prefix (error, "fdatasync");
+    }
+
+  const GLnxLinkTmpfileReplaceMode replacemode =
+    (copyflags & GLNX_FILE_COPY_OVERWRITE) ?
+    GLNX_LINK_TMPFILE_REPLACE :
+    GLNX_LINK_TMPFILE_NOREPLACE;
+
+  if (!glnx_link_tmpfile_at (&tmp_dest, replacemode, dest_dfd, dest_subpath, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * glnx_file_replace_contents_at:
+ * @dfd: Directory fd
+ * @subpath: Subpath
+ * @buf: (array len=len) (element-type guint8): File contents
+ * @len: Length (if `-1`, assume @buf is `NUL` terminated)
+ * @flags: Flags
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Create a new file, atomically replacing the contents of @subpath
+ * (relative to @dfd) with @buf.  By default, if the file already
+ * existed, fdatasync() will be used before rename() to ensure stable
+ * contents.  This and other behavior can be controlled via @flags.
+ *
+ * Note that no metadata from the existing file is preserved, such as
+ * uid/gid or extended attributes.  The default mode will be `0644`.
+ */ 
+gboolean
+glnx_file_replace_contents_at (int                   dfd,
+                               const char           *subpath,
+                               const guint8         *buf,
+                               gsize                 len,
+                               GLnxFileReplaceFlags  flags,
+                               GCancellable         *cancellable,
+                               GError              **error)
+{
+  return glnx_file_replace_contents_with_perms_at (dfd, subpath, buf, len,
+                                                   (mode_t) -1, (uid_t) -1, (gid_t) -1,
+                                                   flags, cancellable, error);
+}
+
+/**
+ * glnx_file_replace_contents_with_perms_at:
+ * @dfd: Directory fd
+ * @subpath: Subpath
+ * @buf: (array len=len) (element-type guint8): File contents
+ * @len: Length (if `-1`, assume @buf is `NUL` terminated)
+ * @mode: File mode; if `-1`, use `0644`
+ * @flags: Flags
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Like glnx_file_replace_contents_at(), but also supports
+ * setting mode, and uid/gid.
+ */ 
+gboolean
+glnx_file_replace_contents_with_perms_at (int                   dfd,
+                                          const char           *subpath,
+                                          const guint8         *buf,
+                                          gsize                 len,
+                                          mode_t                mode,
+                                          uid_t                 uid,
+                                          gid_t                 gid,
+                                          GLnxFileReplaceFlags  flags,
+                                          G_GNUC_UNUSED GCancellable *cancellable,
+                                          GError              **error)
+{
+  char *dnbuf = strdupa (subpath);
+  const char *dn = dirname (dnbuf);
+  gboolean increasing_mtime = (flags & GLNX_FILE_REPLACE_INCREASING_MTIME) != 0;
+  gboolean nodatasync = (flags & GLNX_FILE_REPLACE_NODATASYNC) != 0;
+  gboolean datasync_new = (flags & GLNX_FILE_REPLACE_DATASYNC_NEW) != 0;
+  struct stat stbuf;
+  gboolean has_stbuf = FALSE;
+
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  /* With O_TMPFILE we can't use umask, and we can't sanely query the
+   * umask...let's assume something relatively standard.
+   */
+  if (mode == (mode_t) -1)
+    mode = 0644;
+
+  g_auto(GLnxTmpfile) tmpf = { 0, };
+  if (!glnx_open_tmpfile_linkable_at (dfd, dn, O_WRONLY | O_CLOEXEC,
+                                      &tmpf, error))
+    return FALSE;
+
+  if (len == (gsize) -1)
+    len = strlen ((char*)buf);
+
+  if (!glnx_try_fallocate (tmpf.fd, 0, len, error))
+    return FALSE;
+
+  if (glnx_loop_write (tmpf.fd, buf, len) < 0)
+    return glnx_throw_errno_prefix (error, "write");
+
+  if (!nodatasync || increasing_mtime)
+    {
+      if (!glnx_fstatat_allow_noent (dfd, subpath, &stbuf, AT_SYMLINK_NOFOLLOW, error))
+        return FALSE;
+      has_stbuf = errno != ENOENT;
+    }
+
+  if (!nodatasync)
+    {
+      gboolean do_sync;
+      if (!has_stbuf)
+        do_sync = datasync_new;
+      else
+        do_sync = TRUE;
+
+      if (do_sync)
+        {
+          if (TEMP_FAILURE_RETRY (fdatasync (tmpf.fd)) != 0)
+            return glnx_throw_errno_prefix (error, "fdatasync");
+        }
+    }
+
+  if (uid != (uid_t) -1)
+    {
+      if (TEMP_FAILURE_RETRY (fchown (tmpf.fd, uid, gid)) != 0)
+        return glnx_throw_errno_prefix (error, "fchown");
+    }
+
+  if (TEMP_FAILURE_RETRY (fchmod (tmpf.fd, mode)) != 0)
+    return glnx_throw_errno_prefix (error, "fchmod");
+
+  if (increasing_mtime && has_stbuf)
+    {
+      struct stat fd_stbuf;
+
+      if (fstat (tmpf.fd, &fd_stbuf) != 0)
+        return glnx_throw_errno_prefix (error, "fstat");
+
+      /* We want to ensure that the new file has a st_mtime (i.e. the second precision)
+       * is incrementing to avoid mtime check issues when files change often.
+       */
+      if (fd_stbuf.st_mtime <= stbuf.st_mtime)
+        {
+          struct timespec ts[2] = { {0, UTIME_OMIT}, {stbuf.st_mtime + 1, 0} };
+          if (TEMP_FAILURE_RETRY (futimens (tmpf.fd, ts)) != 0)
+            return glnx_throw_errno_prefix (error, "futimens");
+        }
+    }
+
+  if (!glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_REPLACE,
+                             dfd, subpath, error))
+    return FALSE;
+
+  return TRUE;
+}

--- a/subprojects/libglnx/glnx-fdio.h
+++ b/subprojects/libglnx/glnx-fdio.h
@@ -1,0 +1,386 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-backport-autocleanups.h>
+#include <gio/gfiledescriptorbased.h>
+#include <limits.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <sys/xattr.h>
+// For dirname(), and previously basename()
+#include <libgen.h>
+
+#include <glnx-macros.h>
+#include <glnx-errors.h>
+
+G_BEGIN_DECLS
+
+/* Irritatingly, g_basename() which is what we want
+ * is deprecated.
+ */
+static inline
+const char *glnx_basename (const char *path)
+{
+  const gchar *base = strrchr (path, G_DIR_SEPARATOR);
+
+  if (base)
+    return base + 1;
+
+  return path;
+}
+
+/* Utilities for standard FILE* */
+static inline void
+glnx_stdio_file_cleanup (void *filep)
+{
+  FILE *f = (FILE*)filep;
+  if (f)
+    fclose (f);
+}
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FILE, glnx_stdio_file_cleanup)
+
+/**
+ * glnx_stdio_file_flush:
+ * Call fflush() and check ferror().
+ */
+gboolean
+glnx_stdio_file_flush (FILE *f, GError **error);
+
+typedef struct {
+  gboolean initialized;
+  gboolean anonymous;
+  int src_dfd;
+  int fd;
+  char *path;
+} GLnxTmpfile;
+void glnx_tmpfile_clear (GLnxTmpfile *tmpf);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxTmpfile, glnx_tmpfile_clear)
+
+gboolean
+glnx_open_anonymous_tmpfile (int flags,
+                             GLnxTmpfile *out_tmpf,
+                             GError **error);
+
+gboolean
+glnx_open_anonymous_tmpfile_full (int flags,
+                                  const char *dir,
+                                  GLnxTmpfile *out_tmpf,
+                                  GError **error);
+
+
+gboolean
+glnx_open_tmpfile_linkable_at (int dfd,
+                               const char *subpath,
+                               int flags,
+                               GLnxTmpfile *out_tmpf,
+                               GError **error);
+
+typedef enum {
+  GLNX_LINK_TMPFILE_REPLACE,
+  GLNX_LINK_TMPFILE_NOREPLACE,
+  GLNX_LINK_TMPFILE_NOREPLACE_IGNORE_EXIST
+} GLnxLinkTmpfileReplaceMode;
+
+gboolean
+glnx_link_tmpfile_at (GLnxTmpfile *tmpf,
+                      GLnxLinkTmpfileReplaceMode flags,
+                      int target_dfd,
+                      const char *target,
+                      GError **error);
+
+gboolean
+glnx_tmpfile_reopen_rdonly (GLnxTmpfile *tmpf,
+                            GError **error);
+
+gboolean
+glnx_openat_rdonly (int             dfd,
+                    const char     *path,
+                    gboolean        follow,
+                    int            *out_fd,
+                    GError        **error);
+
+GBytes *
+glnx_fd_readall_bytes (int               fd,
+                       GCancellable     *cancellable,
+                       GError          **error);
+
+char *
+glnx_fd_readall_utf8 (int               fd,
+                      gsize            *out_len,
+                      GCancellable     *cancellable,
+                      GError          **error);
+
+char *
+glnx_file_get_contents_utf8_at (int                   dfd,
+                                const char           *subpath,
+                                gsize                *out_len,
+                                GCancellable         *cancellable,
+                                GError              **error);
+
+/**
+ * GLnxFileReplaceFlags:
+ * @GLNX_FILE_REPLACE_DATASYNC_NEW: Call fdatasync() even if the file did not exist
+ * @GLNX_FILE_REPLACE_NODATASYNC: Never call fdatasync()
+ * @GLNX_FILE_REPLACE_INCREASING_MTIME: Ensure that st_mtime increases (in second precision)
+ *
+ * Flags controlling file replacement.
+ */
+typedef enum {
+  GLNX_FILE_REPLACE_DATASYNC_NEW = (1 << 0),
+  GLNX_FILE_REPLACE_NODATASYNC = (1 << 1),
+  GLNX_FILE_REPLACE_INCREASING_MTIME = (1 << 2),
+} GLnxFileReplaceFlags;
+
+gboolean
+glnx_file_replace_contents_at (int                   dfd,
+                               const char           *subpath,
+                               const guint8         *buf,
+                               gsize                 len,
+                               GLnxFileReplaceFlags  flags,
+                               GCancellable         *cancellable,
+                               GError              **error);
+
+gboolean
+glnx_file_replace_contents_with_perms_at (int                   dfd,
+                                          const char           *subpath,
+                                          const guint8         *buf,
+                                          gsize                 len,
+                                          mode_t                mode,
+                                          uid_t                 uid,
+                                          gid_t                 gid,
+                                          GLnxFileReplaceFlags  flags,
+                                          GCancellable         *cancellable,
+                                          GError              **error);
+
+char *
+glnx_readlinkat_malloc (int            dfd,
+                        const char    *subpath,
+                        GCancellable  *cancellable,
+                        GError       **error);
+
+int
+glnx_loop_write (int fd, const void *buf, size_t nbytes);
+
+int
+glnx_regfile_copy_bytes (int fdf, int fdt, off_t max_bytes);
+
+typedef enum {
+  GLNX_FILE_COPY_OVERWRITE = (1 << 0),
+  GLNX_FILE_COPY_NOXATTRS = (1 << 1),
+  GLNX_FILE_COPY_DATASYNC = (1 << 2),
+  GLNX_FILE_COPY_NOCHOWN = (1 << 3)
+} GLnxFileCopyFlags;
+
+gboolean
+glnx_file_copy_at (int                   src_dfd,
+                   const char           *src_subpath,
+                   const struct stat    *src_stbuf,
+                   int                   dest_dfd,
+                   const char           *dest_subpath,
+                   GLnxFileCopyFlags     copyflags,
+                   GCancellable         *cancellable,
+                   GError              **error);
+
+int glnx_renameat2_noreplace (int olddirfd, const char *oldpath,
+                              int newdirfd, const char *newpath);
+int glnx_renameat2_exchange (int olddirfd, const char *oldpath,
+                             int newdirfd, const char *newpath);
+
+#ifdef _GNU_SOURCE
+/**
+ * glnx_try_fallocate:
+ * @fd: File descriptor
+ * @size: Size
+ * @error: Error
+ *
+ * Wrapper for Linux fallocate().  Explicitly ignores a @size of zero.
+ * Also, will silently do nothing if the underlying filesystem doesn't
+ * support it.  Use this instead of posix_fallocate(), since the glibc fallback
+ * is bad: https://sourceware.org/bugzilla/show_bug.cgi?id=18515
+ */
+static inline gboolean
+glnx_try_fallocate (int      fd,
+                    off_t    offset,
+                    off_t    size,
+                    GError **error)
+{
+  /* This is just nicer than throwing an error */
+  if (size == 0)
+    return TRUE;
+
+  if (fallocate (fd, 0, offset, size) < 0)
+    {
+      if (G_IN_SET(errno, ENOSYS, EOPNOTSUPP))
+        ; /* Ignore */
+      else
+        return glnx_throw_errno_prefix (error, "fallocate");
+    }
+
+  return TRUE;
+}
+#endif
+
+/**
+ * glnx_fstat:
+ * @fd: FD to stat
+ * @buf: (out caller-allocates): Return location for stat details
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Wrapper around fstat() which adds #GError support and ensures that it retries
+ * on %EINTR.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: UNRELEASED
+ */
+static inline gboolean
+glnx_fstat (int           fd,
+            struct stat  *buf,
+            GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (fstat (fd, buf)) != 0)
+    return glnx_throw_errno_prefix (error, "fstat");
+  return TRUE;
+}
+
+/**
+ * glnx_fchmod:
+ * @fd: FD
+ * @mode: Mode
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Wrapper around fchmod() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: UNRELEASED
+ */
+static inline gboolean
+glnx_fchmod (int           fd,
+             mode_t        mode,
+             GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (fchmod (fd, mode)) != 0)
+    return glnx_throw_errno_prefix (error, "fchmod");
+  return TRUE;
+}
+
+/**
+ * glnx_fstatat:
+ * @dfd: Directory FD to stat beneath
+ * @path: Path to stat beneath @dfd
+ * @buf: (out caller-allocates): Return location for stat details
+ * @flags: Flags to pass to fstatat()
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Wrapper around fstatat() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: UNRELEASED
+ */
+static inline gboolean
+glnx_fstatat (int           dfd,
+              const gchar  *path,
+              struct stat  *buf,
+              int           flags,
+              GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, buf, flags)) != 0)
+    return glnx_throw_errno_prefix (error, "fstatat(%s)", path);
+  return TRUE;
+}
+
+/**
+ * glnx_fstatat_allow_noent:
+ * @dfd: Directory FD to stat beneath
+ * @path: Path to stat beneath @dfd
+ * @buf: (out caller-allocates) (allow-none): Return location for stat details
+ * @flags: Flags to pass to fstatat()
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Like glnx_fstatat(), but handles `ENOENT` in a non-error way.  Instead,
+ * on success `errno` will be zero, otherwise it will be preserved.  Hence
+ * you can test `if (errno == 0)` to conditionalize on the file existing,
+ * or `if (errno == ENOENT)` for non-existence.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise (errno is preserved)
+ * Since: UNRELEASED
+ */
+static inline gboolean
+glnx_fstatat_allow_noent (int               dfd,
+                          const char       *path,
+                          struct stat      *out_buf,
+                          int               flags,
+                          GError          **error)
+{
+  G_GNUC_UNUSED struct stat unused_stbuf;
+  if (TEMP_FAILURE_RETRY (fstatat (dfd, path, out_buf ? out_buf : &unused_stbuf, flags)) != 0)
+    {
+      if (errno != ENOENT)
+        return glnx_throw_errno_prefix (error, "fstatat(%s)", path);
+      /* Note we preserve errno as ENOENT */
+    }
+  else
+    errno = 0;
+  return TRUE;
+}
+
+/**
+ * glnx_renameat:
+ *
+ * Wrapper around renameat() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ */
+static inline gboolean
+glnx_renameat (int           src_dfd,
+               const gchar  *src_path,
+               int           dest_dfd,
+               const gchar  *dest_path,
+               GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (renameat (src_dfd, src_path, dest_dfd, dest_path)) != 0)
+    return glnx_throw_errno_prefix (error, "renameat(%s, %s)", src_path, dest_path);
+  return TRUE;
+}
+
+/**
+ * glnx_unlinkat:
+ *
+ * Wrapper around unlinkat() which adds #GError support and ensures that it
+ * retries on %EINTR.
+ */
+static inline gboolean
+glnx_unlinkat (int           dfd,
+               const gchar  *path,
+               int           flags,
+               GError      **error)
+{
+  if (TEMP_FAILURE_RETRY (unlinkat (dfd, path, flags)) != 0)
+    return glnx_throw_errno_prefix (error, "unlinkat(%s)", path);
+  return TRUE;
+}
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-local-alloc.c
+++ b/subprojects/libglnx/glnx-local-alloc.c
@@ -1,0 +1,73 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2012,2015 Colin Walters <walters@verbum.org>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include "glnx-local-alloc.h"
+
+/**
+ * SECTION:glnxlocalalloc
+ * @title: GLnx local allocation
+ * @short_description: Release local variables automatically when they go out of scope
+ *
+ * These macros leverage the GCC extension __attribute__ ((cleanup))
+ * to allow calling a cleanup function such as g_free() when a
+ * variable goes out of scope.  See <ulink
+ * url="http://gcc.gnu.org/onlinedocs/gcc/Variable-Attributes.html">
+ * for more information on the attribute.
+ *
+ * The provided macros make it easy to use the cleanup attribute for
+ * types that come with GLib.  The primary two are #glnx_free and
+ * #glnx_unref_object, which correspond to g_free() and
+ * g_object_unref(), respectively.
+ *
+ * The rationale behind this is that particularly when handling error
+ * paths, it can be very tricky to ensure the right variables are
+ * freed.  With this, one simply applies glnx_unref_object to a
+ * locally-allocated #GFile for example, and it will be automatically
+ * unreferenced when it goes out of scope.
+ *
+ * Note - you should only use these macros for <emphasis>stack
+ * allocated</emphasis> variables.  They don't provide garbage
+ * collection or let you avoid freeing things.  They're simply a
+ * compiler assisted deterministic mechanism for calling a cleanup
+ * function when a stack frame ends.
+ *
+ * <example id="gs-lfree"><title>Calling g_free automatically</title>
+ * <programlisting>
+ *
+ * GFile *
+ * create_file (GError **error)
+ * {
+ *   glnx_free char *random_id = NULL;
+ *
+ *   if (!prepare_file (error))
+ *     return NULL;
+ *
+ *   random_id = alloc_random_id ();
+ *
+ *   return create_file_real (error);
+ *   // Note that random_id is freed here automatically
+ * }
+ * </programlisting>
+ * </example>
+ *
+ */

--- a/subprojects/libglnx/glnx-local-alloc.h
+++ b/subprojects/libglnx/glnx-local-alloc.h
@@ -1,0 +1,89 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2012,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+#include <errno.h>
+
+#include "glnx-backports.h"
+
+G_BEGIN_DECLS
+
+/**
+ * glnx_unref_object:
+ *
+ * Call g_object_unref() on a variable location when it goes out of
+ * scope.  Note that unlike g_object_unref(), the variable may be
+ * %NULL.
+ */
+#define glnx_unref_object __attribute__ ((cleanup(glnx_local_obj_unref)))
+static inline void
+glnx_local_obj_unref (void *v)
+{
+  GObject *o = *(GObject **)v;
+  if (o)
+    g_object_unref (o);
+}
+#define glnx_unref_object __attribute__ ((cleanup(glnx_local_obj_unref)))
+
+/* Backwards-compat with older libglnx */
+#define glnx_steal_fd g_steal_fd
+
+/**
+ * glnx_close_fd:
+ * @fdp: Pointer to fd
+ *
+ * Effectively `close (g_steal_fd (&fd))`.  Also
+ * asserts that `close()` did not raise `EBADF` - encountering
+ * that error is usually a critical bug in the program.
+ */
+static inline void
+glnx_close_fd (int *fdp)
+{
+  int errsv;
+
+  g_assert (fdp);
+
+  int fd = g_steal_fd (fdp);
+  if (fd >= 0)
+    {
+      errsv = errno;
+      if (close (fd) < 0)
+        g_assert (errno != EBADF);
+      errno = errsv;
+    }
+}
+
+/**
+ * glnx_fd_close:
+ *
+ * Deprecated in favor of `glnx_autofd`.
+ */
+#define glnx_fd_close __attribute__((cleanup(glnx_close_fd)))
+/**
+ * glnx_autofd:
+ *
+ * Call close() on a variable location when it goes out of scope.
+ */
+#define glnx_autofd __attribute__((cleanup(glnx_close_fd)))
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-lockfile.c
+++ b/subprojects/libglnx/glnx-lockfile.c
@@ -1,0 +1,180 @@
+/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
+
+/***
+  This file is part of systemd.
+  Now copied into libglnx:
+    - Use GError
+
+  Copyright 2010 Lennart Poettering
+  Copyright 2015 Colin Walters <walters@verbum.org>
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "libglnx-config.h"
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <limits.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "glnx-lockfile.h"
+#include "glnx-errors.h"
+#include "glnx-fdio.h"
+#include "glnx-backport-autocleanups.h"
+#include "glnx-local-alloc.h"
+
+#define newa(t, n) ((t*) alloca(sizeof(t)*(n)))
+
+/**
+ * glnx_make_lock_file:
+ * @dfd: Directory file descriptor (if not `AT_FDCWD`, must have lifetime `>=` @out_lock)
+ * @p: Path
+ * @operation: one of `LOCK_SH`, `LOCK_EX`, `LOCK_UN`, as passed to flock()
+ * @out_lock: (out) (caller allocates): Return location for lock
+ * @error: Error
+ *
+ * Block until a lock file named @p (relative to @dfd) can be created,
+ * using the flags in @operation, returning the lock data in the
+ * caller-allocated location @out_lock.
+ *
+ * This API wraps new-style process locking if available, otherwise
+ * falls back to BSD locks.
+ */
+gboolean
+glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *out_lock, GError **error) {
+        glnx_autofd int fd = -1;
+        g_autofree char *t = NULL;
+        int r;
+
+        /*
+         * We use UNPOSIX locks if they are available. They have nice
+         * semantics, and are mostly compatible with NFS. However,
+         * they are only available on new kernels. When we detect we
+         * are running on an older kernel, then we fall back to good
+         * old BSD locks. They also have nice semantics, but are
+         * slightly problematic on NFS, where they are upgraded to
+         * POSIX locks, even though locally they are orthogonal to
+         * POSIX locks.
+         */
+
+        t = g_strdup(p);
+
+        for (;;) {
+#ifdef F_OFD_SETLK
+                struct flock fl = {
+                        .l_type = (operation & ~LOCK_NB) == LOCK_EX ? F_WRLCK : F_RDLCK,
+                        .l_whence = SEEK_SET,
+                };
+#endif
+                struct stat st;
+
+                fd = openat(dfd, p, O_CREAT|O_RDWR|O_NOFOLLOW|O_CLOEXEC|O_NOCTTY, 0600);
+                if (fd < 0)
+                        return glnx_throw_errno(error);
+
+                /* Unfortunately, new locks are not in RHEL 7.1 glibc */
+#ifdef F_OFD_SETLK
+                r = fcntl(fd, (operation & LOCK_NB) ? F_OFD_SETLK : F_OFD_SETLKW, &fl);
+#else
+                r = -1;
+                errno = EINVAL;
+#endif
+                if (r < 0) {
+
+                        /* If the kernel is too old, use good old BSD locks */
+                        if (errno == EINVAL)
+                                r = flock(fd, operation);
+
+                        if (r < 0)
+                                return glnx_throw_errno_prefix (error, "flock");
+                }
+
+                /* If we acquired the lock, let's check if the file
+                 * still exists in the file system. If not, then the
+                 * previous exclusive owner removed it and then closed
+                 * it. In such a case our acquired lock is worthless,
+                 * hence try again. */
+
+                if (!glnx_fstat (fd, &st, error))
+                        return FALSE;
+                if (st.st_nlink > 0)
+                        break;
+
+                glnx_close_fd (&fd);
+        }
+
+        /* Note that if this is not AT_FDCWD, the caller takes responsibility
+         * for the fd's lifetime being >= that of the lock.
+         */
+        out_lock->initialized = TRUE;
+        out_lock->dfd = dfd;
+        out_lock->path = g_steal_pointer (&t);
+        out_lock->fd = g_steal_fd (&fd);
+        out_lock->operation = operation;
+        return TRUE;
+}
+
+void glnx_release_lock_file(GLnxLockFile *f) {
+        int r;
+
+        if (!(f && f->initialized))
+                return;
+
+        if (f->path) {
+
+                /* If we are the exclusive owner we can safely delete
+                 * the lock file itself. If we are not the exclusive
+                 * owner, we can try becoming it. */
+
+                if (f->fd >= 0 &&
+                    (f->operation & ~LOCK_NB) == LOCK_SH) {
+#ifdef F_OFD_SETLK
+                        static const struct flock fl = {
+                                .l_type = F_WRLCK,
+                                .l_whence = SEEK_SET,
+                        };
+
+                        r = fcntl(f->fd, F_OFD_SETLK, &fl);
+#else
+                        r = -1;
+                        errno = EINVAL;
+#endif
+                        if (r < 0 && errno == EINVAL)
+                                r = flock(f->fd, LOCK_EX|LOCK_NB);
+
+                        if (r >= 0)
+                                f->operation = LOCK_EX|LOCK_NB;
+                }
+
+                if ((f->operation & ~LOCK_NB) == LOCK_EX) {
+                        (void) unlinkat(f->dfd, f->path, 0);
+                }
+
+                g_free(f->path);
+                f->path = NULL;
+        }
+
+        glnx_close_fd (&f->fd);
+        f->operation = 0;
+        f->initialized = FALSE;
+}

--- a/subprojects/libglnx/glnx-lockfile.h
+++ b/subprojects/libglnx/glnx-lockfile.h
@@ -1,0 +1,39 @@
+/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
+
+#pragma once
+
+/***
+  This file is part of systemd.
+
+  Copyright 2011 Lennart Poettering
+  Copyright 2015 Colin Walters <walters@verbum.org>
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+#include "glnx-backport-autoptr.h"
+
+typedef struct GLnxLockFile {
+        gboolean initialized;
+        int dfd;
+        char *path;
+        int fd;
+        int operation;
+} GLnxLockFile;
+
+gboolean glnx_make_lock_file(int dfd, const char *p, int operation, GLnxLockFile *ret, GError **error);
+void glnx_release_lock_file(GLnxLockFile *f);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GLnxLockFile, glnx_release_lock_file)

--- a/subprojects/libglnx/glnx-macros.h
+++ b/subprojects/libglnx/glnx-macros.h
@@ -1,0 +1,200 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Colin Walters <walters@verbum.org>
+ * With original source from systemd:
+ * Copyright 2010 Lennart Poettering
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+/* All of these are for C only. */
+#ifndef __GI_SCANNER__
+
+/* fixes builds against musl, taken from glibc unistd.h */
+#ifndef TEMP_FAILURE_RETRY
+#define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif
+
+/* Taken from https://github.com/systemd/systemd/src/basic/string-util.h
+ * at revision v228-666-gcf6c8c4
+ */
+#define glnx_strjoina(a, ...)                                           \
+        ({                                                              \
+                const char *_appendees_[] = { a, __VA_ARGS__ };         \
+                char *_d_, *_p_;                                        \
+                size_t _len_ = 0;                                       \
+                unsigned _i_;                                           \
+                for (_i_ = 0; _i_ < G_N_ELEMENTS(_appendees_) && _appendees_[_i_]; _i_++) \
+                        _len_ += strlen(_appendees_[_i_]);              \
+                _p_ = _d_ = (char*) alloca(_len_ + 1);                          \
+                for (_i_ = 0; _i_ < G_N_ELEMENTS(_appendees_) && _appendees_[_i_]; _i_++) \
+                        _p_ = stpcpy(_p_, _appendees_[_i_]);            \
+                *_p_ = 0;                                               \
+                _d_;                                                    \
+        })
+
+#ifndef G_IN_SET
+
+/* Infrastructure for `G_IN_SET`; this code is copied from
+ * systemd's macro.h - please treat that version as canonical
+ * and submit patches first to systemd.
+ */
+#define _G_INSET_CASE_F(X) case X:
+#define _G_INSET_CASE_F_1(CASE, X) _G_INSET_CASE_F(X)
+#define _G_INSET_CASE_F_2(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_1(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_3(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_2(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_4(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_3(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_5(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_4(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_6(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_5(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_7(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_6(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_8(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_7(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_9(CASE, X, ...)  CASE(X) _G_INSET_CASE_F_8(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_10(CASE, X, ...) CASE(X) _G_INSET_CASE_F_9(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_11(CASE, X, ...) CASE(X) _G_INSET_CASE_F_10(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_12(CASE, X, ...) CASE(X) _G_INSET_CASE_F_11(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_13(CASE, X, ...) CASE(X) _G_INSET_CASE_F_12(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_14(CASE, X, ...) CASE(X) _G_INSET_CASE_F_13(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_15(CASE, X, ...) CASE(X) _G_INSET_CASE_F_14(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_16(CASE, X, ...) CASE(X) _G_INSET_CASE_F_15(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_17(CASE, X, ...) CASE(X) _G_INSET_CASE_F_16(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_18(CASE, X, ...) CASE(X) _G_INSET_CASE_F_17(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_19(CASE, X, ...) CASE(X) _G_INSET_CASE_F_18(CASE, __VA_ARGS__)
+#define _G_INSET_CASE_F_20(CASE, X, ...) CASE(X) _G_INSET_CASE_F_19(CASE, __VA_ARGS__)
+
+#define _G_INSET_GET_CASE_F(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,_16,_17,_18,_19,_20,NAME,...) NAME
+#define _G_INSET_FOR_EACH_MAKE_CASE(...) \
+  _G_INSET_GET_CASE_F(__VA_ARGS__,_G_INSET_CASE_F_20,_G_INSET_CASE_F_19,_G_INSET_CASE_F_18,_G_INSET_CASE_F_17,_G_INSET_CASE_F_16,_G_INSET_CASE_F_15,_G_INSET_CASE_F_14,_G_INSET_CASE_F_13,_G_INSET_CASE_F_12,_G_INSET_CASE_F_11, \
+                               _G_INSET_CASE_F_10,_G_INSET_CASE_F_9,_G_INSET_CASE_F_8,_G_INSET_CASE_F_7,_G_INSET_CASE_F_6,_G_INSET_CASE_F_5,_G_INSET_CASE_F_4,_G_INSET_CASE_F_3,_G_INSET_CASE_F_2,_G_INSET_CASE_F_1) \
+                   (_G_INSET_CASE_F,__VA_ARGS__)
+
+/* Note: claiming the name here even though it isn't upstream yet
+ * https://bugzilla.gnome.org/show_bug.cgi?id=783751
+ */
+/**
+ * G_IN_SET:
+ * @x: Integer (or smaller) sized value
+ * @...: Elements to compare
+ *
+ * It's quite common to test whether or not `char` values or Unix @errno (among) others
+ * are members of a small set.  Normally one has to choose to either use `if (x == val || x == otherval ...)`
+ * or a `switch` statement.  This macro is useful to reduce duplication in the first case,
+ * where one can write simply `if (G_IN_SET (x, val, otherval))`, and avoid the verbosity
+ * that the `switch` statement requires.
+ */
+#define G_IN_SET(x, ...)                          \
+        ({                                      \
+                gboolean _g_inset_found = FALSE;            \
+                /* If the build breaks in the line below, you need to extend the case macros */ \
+                static G_GNUC_UNUSED char _static_assert__macros_need_to_be_extended[20 - sizeof((int[]){__VA_ARGS__})/sizeof(int)]; \
+                switch(x) {                     \
+                _G_INSET_FOR_EACH_MAKE_CASE(__VA_ARGS__) \
+                        _g_inset_found = TRUE;          \
+                        break;                  \
+                default:                        \
+                        break;                  \
+                }                               \
+                _g_inset_found;                 \
+        })
+
+#endif /* ifndef G_IN_SET */
+
+#define _GLNX_CONCAT(a, b)  a##b
+#define _GLNX_CONCAT_INDIRECT(a, b) _GLNX_CONCAT(a, b)
+#define _GLNX_MAKE_ANONYMOUS(a) _GLNX_CONCAT_INDIRECT(a, __COUNTER__)
+
+#define _GLNX_HASH_TABLE_FOREACH_IMPL_KV(guard, ht, it, kt, k, vt, v)          \
+    gboolean guard = TRUE;                                                     \
+    G_STATIC_ASSERT (sizeof (kt) == sizeof (void*));                           \
+    G_STATIC_ASSERT (sizeof (vt) == sizeof (void*));                           \
+    for (GHashTableIter it;                                                    \
+         guard && ({ g_hash_table_iter_init (&it, ht), TRUE; });               \
+         guard = FALSE)                                                        \
+            for (kt k; guard; guard = FALSE)                                   \
+                for (vt v; g_hash_table_iter_next (&it, (void**)&k, (void**)&v);)
+
+
+/* Cleaner method to iterate over a GHashTable. I.e. rather than
+ *
+ *   gpointer k, v;
+ *   GHashTableIter it;
+ *   g_hash_table_iter_init (&it, table);
+ *   while (g_hash_table_iter_next (&it, &k, &v))
+ *     {
+ *       const char *str = k;
+ *       GPtrArray *arr = v;
+ *       ...
+ *     }
+ *
+ * you can simply do
+ *
+ *   GLNX_HASH_TABLE_FOREACH_IT (table, it, const char*, str, GPtrArray*, arr)
+ *     {
+ *       ...
+ *     }
+ *
+ * All variables are scoped within the loop. You may use the `it` variable as
+ * usual, e.g. to remove an element using g_hash_table_iter_remove(&it). There
+ * are shorter variants for the more common cases where you do not need access
+ * to the iterator or to keys/values:
+ *
+ *   GLNX_HASH_TABLE_FOREACH (table, const char*, str) { ... }
+ *   GLNX_HASH_TABLE_FOREACH_V (table, MyData*, data) { ... }
+ *   GLNX_HASH_TABLE_FOREACH_KV (table, const char*, str, MyData*, data) { ... }
+ *
+ */
+#define GLNX_HASH_TABLE_FOREACH_IT(ht, it, kt, k, vt, v) \
+    _GLNX_HASH_TABLE_FOREACH_IMPL_KV( \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_guard_), ht, it, kt, k, vt, v)
+
+/* Variant of GLNX_HASH_TABLE_FOREACH without having to specify an iterator. An
+ * anonymous iterator will be created. */
+#define GLNX_HASH_TABLE_FOREACH_KV(ht, kt, k, vt, v) \
+    _GLNX_HASH_TABLE_FOREACH_IMPL_KV( \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_guard_), ht, \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_it_), kt, k, vt, v)
+
+/* Variant of GLNX_HASH_TABLE_FOREACH_KV which omits unpacking keys. */
+#define GLNX_HASH_TABLE_FOREACH_V(ht, vt, v) \
+    _GLNX_HASH_TABLE_FOREACH_IMPL_KV( \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_guard_), ht, \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_it_), \
+         gpointer, _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_v_), \
+         vt, v)
+
+/* Variant of GLNX_HASH_TABLE_FOREACH_KV which omits unpacking vals. */
+#define GLNX_HASH_TABLE_FOREACH(ht, kt, k) \
+    _GLNX_HASH_TABLE_FOREACH_IMPL_KV( \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_guard_), ht, \
+         _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_it_), kt, k, \
+         gpointer, _GLNX_MAKE_ANONYMOUS(_glnx_ht_iter_v_))
+
+#endif /* GI_SCANNER */
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-missing-syscall.h
+++ b/subprojects/libglnx/glnx-missing-syscall.h
@@ -1,0 +1,238 @@
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+  Copyright 2016 Zbigniew Jędrzejewski-Szmek
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+/* Missing glibc definitions to access certain kernel APIs.
+   This file is last updated from systemd git:
+
+   commit 71e5200f94b22589922704aa4abdf95d4fe2e528
+   Author:     Daniel Mack <daniel@zonque.org>
+   AuthorDate: Tue Oct 18 17:57:10 2016 +0200
+   Commit:     Lennart Poettering <lennart@poettering.net>
+   CommitDate: Fri Sep 22 15:24:54 2017 +0200
+
+   Add abstraction model for BPF programs
+*/
+
+#include "libglnx-config.h"
+#include <glib.h>
+
+#if !HAVE_DECL_RENAMEAT2
+#  ifndef __NR_renameat2
+#    if defined __x86_64__
+#      define __NR_renameat2 316
+#    elif defined __arm__
+#      define __NR_renameat2 382
+#    elif defined __aarch64__
+#      define __NR_renameat2 276
+#    elif defined _MIPS_SIM
+#      if _MIPS_SIM == _MIPS_SIM_ABI32
+#        define __NR_renameat2 4351
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_NABI32
+#        define __NR_renameat2 6315
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_ABI64
+#        define __NR_renameat2 5311
+#      endif
+#    elif defined __i386__
+#      define __NR_renameat2 353
+#    elif defined __powerpc64__
+#      define __NR_renameat2 357
+#    elif defined __s390__ || defined __s390x__
+#      define __NR_renameat2 347
+#    elif defined __arc__
+#      define __NR_renameat2 276
+#    else
+#      warning "__NR_renameat2 unknown for your architecture"
+#    endif
+#  endif
+
+static inline int renameat2(int oldfd, const char *oldname, int newfd, const char *newname, unsigned flags) {
+#  ifdef __NR_renameat2
+        return syscall(__NR_renameat2, oldfd, oldname, newfd, newname, flags);
+#  else
+        errno = ENOSYS;
+        return -1;
+#  endif
+}
+#endif
+
+#if !HAVE_DECL_MEMFD_CREATE
+#  ifndef __NR_memfd_create
+#    if defined __x86_64__
+#      define __NR_memfd_create 319
+#    elif defined __arm__
+#      define __NR_memfd_create 385
+#    elif defined __aarch64__
+#      define __NR_memfd_create 279
+#    elif defined __s390__
+#      define __NR_memfd_create 350
+#    elif defined _MIPS_SIM
+#      if _MIPS_SIM == _MIPS_SIM_ABI32
+#        define __NR_memfd_create 4354
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_NABI32
+#        define __NR_memfd_create 6318
+#      endif
+#      if _MIPS_SIM == _MIPS_SIM_ABI64
+#        define __NR_memfd_create 5314
+#      endif
+#    elif defined __i386__
+#      define __NR_memfd_create 356
+#    elif defined __arc__
+#      define __NR_memfd_create 279
+#    else
+#      warning "__NR_memfd_create unknown for your architecture"
+#    endif
+#  endif
+
+static inline int memfd_create(const char *name, unsigned int flags) {
+#  ifdef __NR_memfd_create
+        return syscall(__NR_memfd_create, name, flags);
+#  else
+        errno = ENOSYS;
+        return -1;
+#  endif
+}
+#endif
+
+/* Copied from systemd git:
+   commit 6bda23dd6aaba50cf8e3e6024248cf736cc443ca
+   Author:     Yu Watanabe <watanabe.yu+github@gmail.com>
+   AuthorDate: Thu Jul 27 20:22:54 2017 +0900
+   Commit:     Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
+   CommitDate: Thu Jul 27 07:22:54 2017 -0400
+*/
+#if !HAVE_DECL_COPY_FILE_RANGE
+#  ifndef __NR_copy_file_range
+#    if defined(__x86_64__)
+#      define __NR_copy_file_range 326
+#    elif defined(__i386__)
+#      define __NR_copy_file_range 377
+#    elif defined __s390__
+#      define __NR_copy_file_range 375
+#    elif defined __arm__
+#      define __NR_copy_file_range 391
+#    elif defined __aarch64__
+#      define __NR_copy_file_range 285
+#    elif defined __powerpc__
+#      define __NR_copy_file_range 379
+#    elif defined __arc__
+#      define __NR_copy_file_range 285
+#    else
+#      warning "__NR_copy_file_range not defined for your architecture"
+#    endif
+#  endif
+
+static inline ssize_t missing_copy_file_range(int fd_in, loff_t *off_in,
+                                              int fd_out, loff_t *off_out,
+                                              size_t len,
+                                              unsigned int flags) {
+#  ifdef __NR_copy_file_range
+        return syscall(__NR_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags);
+#  else
+        errno = ENOSYS;
+        return -1;
+#  endif
+}
+
+#  define copy_file_range missing_copy_file_range
+#endif
+
+#ifndef __IGNORE_close_range
+#  if defined(__aarch64__)
+#    define systemd_NR_close_range 436
+#  elif defined(__alpha__)
+#    define systemd_NR_close_range 546
+#  elif defined(__arc__) || defined(__tilegx__)
+#    define systemd_NR_close_range 436
+#  elif defined(__arm__)
+#    define systemd_NR_close_range 436
+#  elif defined(__i386__)
+#    define systemd_NR_close_range 436
+#  elif defined(__ia64__)
+#    define systemd_NR_close_range 1460
+#  elif defined(__loongarch_lp64)
+#    define systemd_NR_close_range 436
+#  elif defined(__m68k__)
+#    define systemd_NR_close_range 436
+#  elif defined(_MIPS_SIM)
+#    if _MIPS_SIM == _MIPS_SIM_ABI32
+#      define systemd_NR_close_range 4436
+#    elif _MIPS_SIM == _MIPS_SIM_NABI32
+#      define systemd_NR_close_range 6436
+#    elif _MIPS_SIM == _MIPS_SIM_ABI64
+#      define systemd_NR_close_range 5436
+#    else
+#      error "Unknown MIPS ABI"
+#    endif
+#  elif defined(__hppa__)
+#    define systemd_NR_close_range 436
+#  elif defined(__powerpc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__riscv)
+#    if __riscv_xlen == 32
+#      define systemd_NR_close_range 436
+#    elif __riscv_xlen == 64
+#      define systemd_NR_close_range 436
+#    else
+#      error "Unknown RISC-V ABI"
+#    endif
+#  elif defined(__s390__)
+#    define systemd_NR_close_range 436
+#  elif defined(__sparc__)
+#    define systemd_NR_close_range 436
+#  elif defined(__x86_64__)
+#    if defined(__ILP32__)
+#      define systemd_NR_close_range (436 | /* __X32_SYSCALL_BIT */ 0x40000000)
+#    else
+#      define systemd_NR_close_range 436
+#    endif
+#  elif !defined(missing_arch_template)
+#    warning "close_range() syscall number is unknown for your architecture"
+#  endif
+
+/* may be an (invalid) negative number due to libseccomp, see PR 13319 */
+#  if defined __NR_close_range && __NR_close_range >= 0
+#    if defined systemd_NR_close_range
+G_STATIC_ASSERT(__NR_close_range == systemd_NR_close_range);
+#    endif
+#  else
+#    if defined __NR_close_range
+#      undef __NR_close_range
+#    endif
+#    if defined systemd_NR_close_range && systemd_NR_close_range >= 0
+#      define __NR_close_range systemd_NR_close_range
+#    endif
+#  endif
+#endif
+
+#if !defined(HAVE_CLOSE_RANGE) && defined(__NR_close_range)
+static inline int
+inline_close_range (unsigned int low,
+                    unsigned int high,
+                    int flags)
+{
+  return syscall (__NR_close_range, low, high, flags);
+}
+#define close_range(low, high, flags) inline_close_range(low, high, flags)
+#define HAVE_CLOSE_RANGE
+#endif

--- a/subprojects/libglnx/glnx-missing.h
+++ b/subprojects/libglnx/glnx-missing.h
@@ -1,0 +1,103 @@
+#pragma once
+
+/***
+  This file was originally part of systemd.
+
+  Copyright 2010 Lennart Poettering
+  SPDX-License-Identifier: LGPL-2.1-or-later
+
+  systemd is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+
+  systemd is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with systemd; If not, see <http://www.gnu.org/licenses/>.
+***/
+
+/* Missing glibc definitions to access certain kernel APIs.
+   This file is last updated from systemd git:
+
+   commit 71e5200f94b22589922704aa4abdf95d4fe2e528
+   Author:     Daniel Mack <daniel@zonque.org>
+   AuthorDate: Tue Oct 18 17:57:10 2016 +0200
+   Commit:     Lennart Poettering <lennart@poettering.net>
+   CommitDate: Fri Sep 22 15:24:54 2017 +0200
+
+   Add abstraction model for BPF programs
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+/* The precise definition of __O_TMPFILE is arch specific; use the
+ * values defined by the kernel (note: some are hexa, some are octal,
+ * duplicated as-is from the kernel definitions):
+ * - alpha, parisc, sparc: each has a specific value;
+ * - others: they use the "generic" value.
+ */
+
+#ifndef __O_TMPFILE
+#if defined(__alpha__)
+#define __O_TMPFILE     0100000000
+#elif defined(__parisc__) || defined(__hppa__)
+#define __O_TMPFILE     0400000000
+#elif defined(__sparc__) || defined(__sparc64__)
+#define __O_TMPFILE     0x2000000
+#else
+#define __O_TMPFILE     020000000
+#endif
+#endif
+
+/* a horrid kludge trying to make sure that this will fail on old kernels */
+#ifndef O_TMPFILE
+#define O_TMPFILE (__O_TMPFILE | O_DIRECTORY)
+#endif
+
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1 << 0)
+#endif
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1 << 1)
+#endif
+
+#ifndef F_LINUX_SPECIFIC_BASE
+#define F_LINUX_SPECIFIC_BASE 1024
+#endif
+
+#ifndef F_ADD_SEALS
+#define F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
+#define F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
+
+#define F_SEAL_SEAL     0x0001  /* prevent further seals from being set */
+#define F_SEAL_SHRINK   0x0002  /* prevent file from shrinking */
+#define F_SEAL_GROW     0x0004  /* prevent file from growing */
+#define F_SEAL_WRITE    0x0008  /* prevent writes */
+#endif
+
+#ifndef MFD_ALLOW_SEALING
+#define MFD_ALLOW_SEALING 0x0002U
+#endif
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001U
+#endif
+
+#ifndef CLOSE_RANGE_UNSHARE
+#define CLOSE_RANGE_UNSHARE (1U << 1)
+#endif
+
+#ifndef CLOSE_RANGE_CLOEXEC
+#define CLOSE_RANGE_CLOEXEC (1U << 2)
+#endif
+
+#include "glnx-missing-syscall.h"

--- a/subprojects/libglnx/glnx-shutil.c
+++ b/subprojects/libglnx/glnx-shutil.c
@@ -1,0 +1,269 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <string.h>
+
+#include <glnx-shutil.h>
+#include <glnx-errors.h>
+#include <glnx-fdio.h>
+#include <glnx-local-alloc.h>
+
+static gboolean
+unlinkat_allow_noent (int dfd,
+                      const char *path,
+                      int flags,
+                      GError **error)
+{
+  if (unlinkat (dfd, path, flags) == -1)
+    {
+      if (errno != ENOENT)
+        return glnx_throw_errno_prefix (error, "unlinkat(%s)", path);
+    }
+  return TRUE;
+}
+
+static gboolean
+glnx_shutil_rm_rf_children (GLnxDirFdIterator    *dfd_iter,
+                            GCancellable       *cancellable,
+                            GError            **error)
+{
+  struct dirent *dent;
+
+  while (TRUE)
+    {
+      if (!glnx_dirfd_iterator_next_dent_ensure_dtype (dfd_iter, &dent, cancellable, error))
+        return FALSE;
+      if (dent == NULL)
+        break;
+
+      if (dent->d_type == DT_DIR)
+        {
+          g_auto(GLnxDirFdIterator) child_dfd_iter = { 0, };
+
+          if (!glnx_dirfd_iterator_init_at (dfd_iter->fd, dent->d_name, FALSE,
+                                            &child_dfd_iter, error))
+            return FALSE;
+
+          if (!glnx_shutil_rm_rf_children (&child_dfd_iter, cancellable, error))
+            return FALSE;
+
+          if (!glnx_unlinkat (dfd_iter->fd, dent->d_name, AT_REMOVEDIR, error))
+            return FALSE;
+        }
+      else
+        {
+          if (!unlinkat_allow_noent (dfd_iter->fd, dent->d_name, 0, error))
+            return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
+/**
+ * glnx_shutil_rm_rf_at:
+ * @dfd: A directory file descriptor, or `AT_FDCWD` or `-1` for current
+ * @path: Path
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Recursively delete the filename referenced by the combination of
+ * the directory fd @dfd and @path; it may be a file or directory.  No
+ * error is thrown if @path does not exist.
+ */
+gboolean
+glnx_shutil_rm_rf_at (int                   dfd,
+                      const char           *path,
+                      GCancellable         *cancellable,
+                      GError              **error)
+{
+  dfd = glnx_dirfd_canonicalize (dfd);
+
+  /* With O_NOFOLLOW first */
+  glnx_autofd int target_dfd =
+    openat (dfd, path, O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+
+  if (target_dfd == -1)
+    {
+      int errsv = errno;
+      if (errsv == ENOENT)
+        {
+          ;
+        }
+      else if (errsv == ENOTDIR || errsv == ELOOP)
+        {
+          if (!glnx_unlinkat (dfd, path, 0, error))
+            return FALSE;
+        }
+      else
+        return glnx_throw_errno_prefix (error, "open(%s)", path);
+    }
+  else
+    {
+      g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+      if (!glnx_dirfd_iterator_init_take_fd (&target_dfd, &dfd_iter, error))
+        return FALSE;
+
+      if (!glnx_shutil_rm_rf_children (&dfd_iter, cancellable, error))
+        return glnx_prefix_error (error, "Removing %s", path);
+
+      if (!unlinkat_allow_noent (dfd, path, AT_REMOVEDIR, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+mkdir_p_at_internal (int              dfd,
+                     char            *path,
+                     int              mode,
+                     GCancellable    *cancellable,
+                     GError         **error)
+{
+  gboolean did_recurse = FALSE;
+
+  if (g_cancellable_set_error_if_cancelled (cancellable, error))
+    return FALSE;
+
+ again:
+  if (mkdirat (dfd, path, mode) == -1)
+    {
+      if (errno == ENOENT)
+        {
+          char *lastslash;
+
+          g_assert (!did_recurse);
+
+          lastslash = strrchr (path, '/');
+          if (lastslash == NULL)
+            {
+              /* This can happen if @dfd was deleted between being opened and
+               * passed to mkdir_p_at_internal(). */
+              return glnx_throw_errno_prefix (error, "mkdir(%s)", path);
+            }
+
+          /* Note we can mutate the buffer as we dup'd it */
+          *lastslash = '\0';
+
+          if (!glnx_shutil_mkdir_p_at (dfd, path, mode,
+                                       cancellable, error))
+            return FALSE;
+
+          /* Now restore it for another mkdir attempt */
+          *lastslash = '/';
+
+          did_recurse = TRUE;
+          goto again;
+        }
+      else if (errno == EEXIST)
+        {
+          /* Fall through; it may not have been a directory,
+           * but we'll find that out on the next call up.
+           */
+        }
+      else
+        return glnx_throw_errno_prefix (error, "mkdir(%s)", path);
+    }
+
+  return TRUE;
+}
+
+/**
+ * glnx_shutil_mkdir_p_at:
+ * @dfd: Directory fd
+ * @path: Directory path to be created
+ * @mode: Mode for newly created directories
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Similar to g_mkdir_with_parents(), except operates relative to the
+ * directory fd @dfd.
+ *
+ * See also glnx_ensure_dir() for a non-recursive version.
+ *
+ * This will return %G_IO_ERROR_NOT_FOUND if @dfd has been deleted since being
+ * opened. It may return other errors from mkdirat() in other situations.
+ */
+gboolean
+glnx_shutil_mkdir_p_at (int                   dfd,
+                        const char           *path,
+                        int                   mode,
+                        GCancellable         *cancellable,
+                        GError              **error)
+{
+  struct stat stbuf;
+  char *buf;
+
+  /* Fast path stat to see whether it already exists */
+  if (fstatat (dfd, path, &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
+    {
+      /* Note early return */
+      if (S_ISDIR (stbuf.st_mode))
+        return TRUE;
+    }
+
+  buf = strdupa (path);
+
+  if (!mkdir_p_at_internal (dfd, buf, mode, cancellable, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+/**
+ * glnx_shutil_mkdir_p_at_open:
+ * @dfd: Directory fd
+ * @path: Directory path to be created
+ * @mode: Mode for newly created directories
+ * @out_dfd: (out caller-allocates): Return location for an FD to @dfd/@path,
+ *    or `-1` on error
+ * @cancellable: (nullable): Cancellable, or %NULL
+ * @error: Return location for a #GError, or %NULL
+ *
+ * Similar to glnx_shutil_mkdir_p_at(), except it opens the resulting directory
+ * and returns a directory FD to it. Currently, this is not guaranteed to be
+ * race-free.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise
+ * Since: UNRELEASED
+ */
+gboolean
+glnx_shutil_mkdir_p_at_open (int            dfd,
+                             const char    *path,
+                             int            mode,
+                             int           *out_dfd,
+                             GCancellable  *cancellable,
+                             GError       **error)
+{
+  /* FIXME: It’s not possible to eliminate the race here until
+   * openat(O_DIRECTORY | O_CREAT) works (and returns a directory rather than a
+   * file). It appears to be not supported in current kernels. (Tested with
+   * 4.10.10-200.fc25.x86_64.) */
+  *out_dfd = -1;
+
+  if (!glnx_shutil_mkdir_p_at (dfd, path, mode, cancellable, error))
+    return FALSE;
+
+  return glnx_opendirat (dfd, path, TRUE, out_dfd, error);
+}

--- a/subprojects/libglnx/glnx-shutil.h
+++ b/subprojects/libglnx/glnx-shutil.h
@@ -1,0 +1,49 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-dirfd.h>
+
+G_BEGIN_DECLS
+
+gboolean
+glnx_shutil_rm_rf_at (int                   dfd,
+                      const char           *path,
+                      GCancellable         *cancellable,
+                      GError              **error);
+
+gboolean
+glnx_shutil_mkdir_p_at (int                   dfd,
+                        const char           *path,
+                        int                   mode,
+                        GCancellable         *cancellable,
+                        GError              **error);
+
+gboolean
+glnx_shutil_mkdir_p_at_open (int            dfd,
+                             const char    *path,
+                             int            mode,
+                             int           *out_dfd,
+                             GCancellable  *cancellable,
+                             GError       **error);
+
+G_END_DECLS

--- a/subprojects/libglnx/glnx-xattrs.c
+++ b/subprojects/libglnx/glnx-xattrs.c
@@ -1,0 +1,445 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+
+#include <string.h>
+#include <stdio.h>
+
+#include <glnx-macros.h>
+#include <glnx-xattrs.h>
+#include <glnx-errors.h>
+#include <glnx-local-alloc.h>
+
+static GVariant *
+variant_new_ay_bytes (GBytes *bytes)
+{
+  gsize size;
+  gconstpointer data;
+  data = g_bytes_get_data (bytes, &size);
+  g_bytes_ref (bytes);
+  return g_variant_new_from_data (G_VARIANT_TYPE ("ay"), data, size,
+                                  TRUE, (GDestroyNotify)g_bytes_unref, bytes);
+}
+
+static char *
+canonicalize_xattrs (char    *xattr_string,
+                     size_t   len)
+{
+  char *p;
+  GSList *xattrs = NULL;
+  GSList *iter;
+  GString *result;
+
+  result = g_string_new (0);
+
+  p = xattr_string;
+  while (p < xattr_string+len)
+    {
+      xattrs = g_slist_prepend (xattrs, p);
+      p += strlen (p) + 1;
+    }
+
+  xattrs = g_slist_sort (xattrs, (GCompareFunc) strcmp);
+  for (iter = xattrs; iter; iter = iter->next) {
+    g_string_append (result, iter->data);
+    g_string_append_c (result, '\0');
+  }
+
+  g_slist_free (xattrs);
+  return g_string_free (result, FALSE);
+}
+
+static gboolean
+read_xattr_name_array (const char *path,
+                       int         fd,
+                       const char *xattrs,
+                       size_t      len,
+                       GVariantBuilder *builder,
+                       GError  **error)
+{
+  gboolean ret = FALSE;
+  const char *p;
+  int r;
+  const char *funcstr;
+
+  g_assert (path != NULL || fd != -1);
+
+  funcstr = fd != -1 ? "fgetxattr" : "lgetxattr";
+
+  for (p = xattrs; p < xattrs+len; p = p + strlen (p) + 1)
+    {
+      ssize_t bytes_read;
+      g_autofree char *buf = NULL;
+      g_autoptr(GBytes) bytes = NULL;
+
+    again:
+      if (fd != -1)
+        bytes_read = fgetxattr (fd, p, NULL, 0);
+      else
+        bytes_read = lgetxattr (path, p, NULL, 0);
+      if (bytes_read < 0)
+        {
+          if (errno == ENODATA)
+            continue;
+
+          glnx_set_prefix_error_from_errno (error, "%s", funcstr);
+          goto out;
+        }
+      if (bytes_read == 0)
+        continue;
+
+      buf = g_malloc (bytes_read);
+      if (fd != -1)
+        r = fgetxattr (fd, p, buf, bytes_read);
+      else
+        r = lgetxattr (path, p, buf, bytes_read);
+      if (r < 0)
+        {
+          if (errno == ERANGE)
+            {
+              g_free (g_steal_pointer (&buf));
+              goto again;
+            }
+          else if (errno == ENODATA)
+            continue;
+
+          glnx_set_prefix_error_from_errno (error, "%s", funcstr);
+          goto out;
+        }
+
+      bytes = g_bytes_new_take (g_steal_pointer (&buf), bytes_read);
+      g_variant_builder_add (builder, "(@ay@ay)",
+                             g_variant_new_bytestring (p),
+                             variant_new_ay_bytes (bytes));
+    }
+
+  ret = TRUE;
+ out:
+  return ret;
+}
+
+static gboolean
+get_xattrs_impl (const char      *path,
+                 int              fd,
+                 GVariant       **out_xattrs,
+                 G_GNUC_UNUSED GCancellable *cancellable,
+                 GError         **error)
+{
+  gboolean ret = FALSE;
+  ssize_t bytes_read, real_size;
+  g_autofree char *xattr_names = NULL;
+  g_autofree char *xattr_names_canonical = NULL;
+  GVariantBuilder builder;
+  gboolean builder_initialized = FALSE;
+  g_autoptr(GVariant) ret_xattrs = NULL;
+
+  g_assert (path != NULL || fd != -1);
+
+  g_variant_builder_init (&builder, G_VARIANT_TYPE ("a(ayay)"));
+  builder_initialized = TRUE;
+
+ again:
+  if (path)
+    bytes_read = llistxattr (path, NULL, 0);
+  else
+    bytes_read = flistxattr (fd, NULL, 0);
+
+  if (bytes_read < 0)
+    {
+      if (errno != ENOTSUP)
+        {
+          glnx_set_prefix_error_from_errno (error, "%s", "llistxattr");
+          goto out;
+        }
+    }
+  else if (bytes_read > 0)
+    {
+      xattr_names = g_malloc (bytes_read);
+      if (path)
+        real_size = llistxattr (path, xattr_names, bytes_read);
+      else
+        real_size = flistxattr (fd, xattr_names, bytes_read);
+      if (real_size < 0)
+        {
+          if (errno == ERANGE)
+            {
+              g_free (g_steal_pointer (&xattr_names));
+              goto again;
+            }
+          glnx_set_prefix_error_from_errno (error, "%s", "llistxattr");
+          goto out;
+        }
+      else if (real_size > 0)
+        {
+          xattr_names_canonical = canonicalize_xattrs (xattr_names, real_size);
+
+          if (!read_xattr_name_array (path, fd, xattr_names_canonical, real_size, &builder, error))
+            goto out;
+        }
+    }
+
+  ret_xattrs = g_variant_builder_end (&builder);
+  builder_initialized = FALSE;
+  g_variant_ref_sink (ret_xattrs);
+  
+  ret = TRUE;
+  if (out_xattrs)
+    *out_xattrs = g_steal_pointer (&ret_xattrs);
+ out:
+  if (!builder_initialized)
+    g_variant_builder_clear (&builder);
+  return ret;
+}
+
+/**
+ * glnx_fd_get_all_xattrs:
+ * @fd: a file descriptor
+ * @out_xattrs: (out): A new #GVariant containing the extended attributes
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Read all extended attributes from @fd in a canonical sorted order, and
+ * set @out_xattrs with the result.
+ *
+ * If the filesystem does not support extended attributes, @out_xattrs
+ * will have 0 elements, and this function will return successfully.
+ */
+gboolean
+glnx_fd_get_all_xattrs (int            fd,
+                        GVariant     **out_xattrs,
+                        GCancellable  *cancellable,
+                        GError       **error)
+{
+  return get_xattrs_impl (NULL, fd, out_xattrs,
+                          cancellable, error);
+}
+
+/**
+ * glnx_dfd_name_get_all_xattrs:
+ * @dfd: Parent directory file descriptor
+ * @name: File name
+ * @out_xattrs: (out): Extended attribute set
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Load all extended attributes for the file named @name residing in
+ * directory @dfd.
+ */
+gboolean
+glnx_dfd_name_get_all_xattrs (int            dfd,
+                              const char    *name,
+                              GVariant     **out_xattrs,
+                              GCancellable  *cancellable,
+                              GError       **error)
+{
+  if (G_IN_SET(dfd, AT_FDCWD, -1))
+    {
+      return get_xattrs_impl (name, -1, out_xattrs, cancellable, error);
+    }
+  else
+    {
+      char buf[PATH_MAX];
+      /* A workaround for the lack of lgetxattrat(), thanks to Florian Weimer:
+       * https://mail.gnome.org/archives/ostree-list/2014-February/msg00017.html
+       */
+      snprintf (buf, sizeof (buf), "/proc/self/fd/%d/%s", dfd, name);
+      return get_xattrs_impl (buf, -1, out_xattrs, cancellable, error);
+    }
+}
+
+static gboolean
+set_all_xattrs_for_path (const char    *path,
+                         GVariant      *xattrs,
+                         G_GNUC_UNUSED GCancellable *cancellable,
+                         GError       **error)
+{
+  const guint n = g_variant_n_children (xattrs);
+  for (guint i = 0; i < n; i++)
+    {
+      const guint8* name;
+      g_autoptr(GVariant) value = NULL;
+      g_variant_get_child (xattrs, i, "(^&ay@ay)",
+                           &name, &value);
+
+      gsize value_len;
+      const guint8* value_data = g_variant_get_fixed_array (value, &value_len, 1);
+
+      if (lsetxattr (path, (char*)name, (char*)value_data, value_len, 0) < 0)
+        return glnx_throw_errno_prefix (error, "lsetxattr(%s)", name);
+    }
+
+  return TRUE;
+}
+
+/**
+ * glnx_dfd_name_set_all_xattrs:
+ * @dfd: Parent directory file descriptor
+ * @name: File name
+ * @xattrs: Extended attribute set
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * Set all extended attributes for the file named @name residing in
+ * directory @dfd.
+ */
+gboolean
+glnx_dfd_name_set_all_xattrs (int            dfd,
+                              const char    *name,
+                              GVariant      *xattrs,
+                              GCancellable  *cancellable,
+                              GError       **error)
+{
+  if (G_IN_SET(dfd, AT_FDCWD, -1))
+    {
+      return set_all_xattrs_for_path (name, xattrs, cancellable, error);
+    }
+  else
+    {
+      char buf[PATH_MAX];
+      /* A workaround for the lack of lsetxattrat(), thanks to Florian Weimer:
+       * https://mail.gnome.org/archives/ostree-list/2014-February/msg00017.html
+       */
+      snprintf (buf, sizeof (buf), "/proc/self/fd/%d/%s", dfd, name);
+      return set_all_xattrs_for_path (buf, xattrs, cancellable, error);
+    }
+}
+
+/**
+ * glnx_fd_set_all_xattrs:
+ * @fd: File descriptor
+ * @xattrs: Extended attributes
+ * @cancellable: Cancellable
+ * @error: Error
+ *
+ * For each attribute in @xattrs, set its value on the file or
+ * directory referred to by @fd.  This function does not remove any
+ * attributes not in @xattrs.
+ */
+gboolean
+glnx_fd_set_all_xattrs (int            fd,
+                        GVariant      *xattrs,
+                        G_GNUC_UNUSED GCancellable *cancellable,
+                        GError       **error)
+{
+  const guint n = g_variant_n_children (xattrs);
+  for (guint i = 0; i < n; i++)
+    {
+      const guint8* name;
+      g_autoptr(GVariant) value = NULL;
+      g_variant_get_child (xattrs, i, "(^&ay@ay)",
+                           &name, &value);
+
+      gsize value_len;
+      const guint8* value_data = g_variant_get_fixed_array (value, &value_len, 1);
+
+      if (TEMP_FAILURE_RETRY (fsetxattr (fd, (char*)name, (char*)value_data, value_len, 0)) < 0)
+        return glnx_throw_errno_prefix (error, "Setting xattrs: fsetxattr(%s)", name);
+    }
+
+  return TRUE;
+}
+
+/**
+ * glnx_lgetxattrat:
+ * @dfd: Directory file descriptor
+ * @subpath: Subpath
+ * @attribute: Extended attribute to retrieve
+ * @error: Error
+ *
+ * Retrieve an extended attribute value, relative to a directory file
+ * descriptor.
+ */
+GBytes *
+glnx_lgetxattrat (int            dfd,
+                  const char    *subpath,
+                  const char    *attribute,
+                  GError       **error)
+{
+  char pathbuf[PATH_MAX];
+  snprintf (pathbuf, sizeof (pathbuf), "/proc/self/fd/%d/%s", dfd, subpath);
+
+  ssize_t bytes_read, real_size;
+  if (TEMP_FAILURE_RETRY (bytes_read = lgetxattr (pathbuf, attribute, NULL, 0)) < 0)
+    return glnx_null_throw_errno_prefix (error, "lgetxattr(%s)", attribute);
+
+  g_autofree guint8 *buf = g_malloc (bytes_read);
+  if (TEMP_FAILURE_RETRY (real_size = lgetxattr (pathbuf, attribute, buf, bytes_read)) < 0)
+    return glnx_null_throw_errno_prefix (error, "lgetxattr(%s)", attribute);
+
+  return g_bytes_new_take (g_steal_pointer (&buf), real_size);
+}
+
+/**
+ * glnx_fgetxattr_bytes:
+ * @fd: Directory file descriptor
+ * @attribute: Extended attribute to retrieve
+ * @error: Error
+ *
+ * Returns: (transfer full): An extended attribute value, or %NULL on error
+ */
+GBytes *
+glnx_fgetxattr_bytes (int            fd,
+                      const char    *attribute,
+                      GError       **error)
+{
+  ssize_t bytes_read, real_size;
+
+  if (TEMP_FAILURE_RETRY (bytes_read = fgetxattr (fd, attribute, NULL, 0)) < 0)
+    return glnx_null_throw_errno_prefix (error, "fgetxattr(%s)", attribute);
+
+  g_autofree guint8 *buf = g_malloc (bytes_read);
+  if (TEMP_FAILURE_RETRY (real_size = fgetxattr (fd, attribute, buf, bytes_read)) < 0)
+    return glnx_null_throw_errno_prefix (error, "fgetxattr(%s)", attribute);
+
+  return g_bytes_new_take (g_steal_pointer (&buf), real_size);
+}
+
+/**
+ * glnx_lsetxattrat:
+ * @dfd: Directory file descriptor
+ * @subpath: Path
+ * @attribute: An attribute name
+ * @value: (array length=len) (element-type guint8): Attribute value
+ * @len: Length of @value
+ * @flags: Flags, containing either XATTR_CREATE or XATTR_REPLACE
+ * @error: Error
+ *
+ * Set an extended attribute, relative to a directory file descriptor.
+ */
+gboolean
+glnx_lsetxattrat (int            dfd,
+                  const char    *subpath,
+                  const char    *attribute,
+                  const guint8  *value,
+                  gsize          len,
+                  int            flags,
+                  GError       **error)
+{
+  char pathbuf[PATH_MAX];
+  snprintf (pathbuf, sizeof (pathbuf), "/proc/self/fd/%d/%s", dfd, subpath);
+
+  if (TEMP_FAILURE_RETRY (lsetxattr (pathbuf, attribute, value, len, flags)) < 0)
+    return glnx_throw_errno_prefix (error, "lsetxattr(%s)", attribute);
+
+  return TRUE;
+}
+

--- a/subprojects/libglnx/glnx-xattrs.h
+++ b/subprojects/libglnx/glnx-xattrs.h
@@ -1,0 +1,79 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2014,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glnx-backport-autocleanups.h>
+#include <limits.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/xattr.h>
+
+G_BEGIN_DECLS
+
+gboolean
+glnx_dfd_name_get_all_xattrs (int                    dfd,
+                              const char            *name,
+                              GVariant             **out_xattrs,
+                              GCancellable          *cancellable,
+                              GError               **error);
+
+gboolean
+glnx_fd_get_all_xattrs (int                    fd,
+                        GVariant             **out_xattrs,
+                        GCancellable          *cancellable,
+                        GError               **error);
+
+gboolean
+glnx_dfd_name_set_all_xattrs (int            dfd,
+                              const char    *name,
+                              GVariant      *xattrs,
+                              GCancellable  *cancellable,
+                              GError       **error);
+
+gboolean
+glnx_fd_set_all_xattrs (int            fd,
+                        GVariant      *xattrs,
+                        GCancellable  *cancellable,
+                        GError       **error);
+
+GBytes *
+glnx_lgetxattrat (int            dfd,
+                  const char    *subpath,
+                  const char    *attribute,
+                  GError       **error);
+
+GBytes *
+glnx_fgetxattr_bytes (int            fd,
+                      const char    *attribute,
+                      GError       **error);
+
+gboolean
+glnx_lsetxattrat (int            dfd,
+                  const char    *subpath,
+                  const char    *attribute,
+                  const guint8  *value,
+                  gsize          len,
+                  int            flags,
+                  GError       **error);
+
+G_END_DECLS

--- a/subprojects/libglnx/libglnx.doap
+++ b/subprojects/libglnx/libglnx.doap
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2015 Colin Walters
+SPDX-License-Identifier: LGPL-2.1-or-later
+-->
+<Project xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:gnome="http://api.gnome.org/doap-extensions#"
+         xmlns="http://usefulinc.com/ns/doap#">
+
+  <name>libglnx</name>
+  <shortname>libglnx</shortname>
+
+  <shortdesc xml:lang="en">"Copylib" for system service modules using GLib with Linux</shortdesc>
+
+  <description xml:lang="en">This module is intended for use by
+  infrastructure code using GLib that is also Linux specific, such as
+  ostree, NetworkManager, and others.
+  </description>
+
+  <license rdf:resource="http://usefulinc.com/doap/licenses/lgpl" />
+  <support-forum rdf:resource="https://discourse.gnome.org/c/platform/5" />
+
+  <programming-language>C</programming-language>
+
+  <maintainer>
+    <foaf:Person>
+      <foaf:name>Colin Walters</foaf:name>
+      <foaf:mbox rdf:resource="mailto:walters@verbum.org"/>
+      <gnome:userid>walters</gnome:userid>
+    </foaf:Person>
+  </maintainer>
+
+</Project>

--- a/subprojects/libglnx/libglnx.h
+++ b/subprojects/libglnx/libglnx.h
@@ -1,0 +1,42 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2012,2013,2015 Colin Walters <walters@verbum.org>.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#include <glnx-macros.h>
+#include <glnx-missing.h>
+#include <glnx-local-alloc.h>
+#include <glnx-backport-autocleanups.h>
+#include <glnx-backport-testutils.h>
+#include <glnx-backports.h>
+#include <glnx-lockfile.h>
+#include <glnx-errors.h>
+#include <glnx-dirfd.h>
+#include <glnx-shutil.h>
+#include <glnx-xattrs.h>
+#include <glnx-console.h>
+#include <glnx-fdio.h>
+
+G_END_DECLS

--- a/subprojects/libglnx/libglnx.m4
+++ b/subprojects/libglnx/libglnx.m4
@@ -1,0 +1,42 @@
+# Copyright 2016 Colin Walters
+# Copyright 2020 Endless OS Foundation LLC
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+AC_DEFUN([LIBGLNX_CONFIGURE],
+[
+dnl This defines HAVE_DECL_FOO to 1 if found or 0 if not
+AC_CHECK_DECLS([
+        renameat2,
+        memfd_create,
+        copy_file_range],
+        [], [], [[
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/mount.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <linux/loop.h>
+#include <linux/random.h>
+#include <sys/mman.h>
+]])
+dnl This defines HAVE_FOO to 1 if found, or leaves it undefined if not:
+dnl not the same!
+AC_CHECK_FUNCS([close_range])
+
+AC_ARG_ENABLE(otmpfile,
+              [AS_HELP_STRING([--disable-otmpfile],
+                              [Disable use of O_TMPFILE [default=no]])],,
+              [enable_otmpfile=yes])
+AS_IF([test $enable_otmpfile = yes], [], [
+  AC_DEFINE([DISABLE_OTMPFILE], 1, [Define if we should avoid using O_TMPFILE])])
+
+AC_ARG_ENABLE(wrpseudo-compat,
+              [AS_HELP_STRING([--enable-wrpseudo-compat],
+                              [Disable use of syscall() in some cases for compatibility with pseudo [default=no]])],,
+              [enable_wrpseudo_compat=no])
+AS_IF([test $enable_wrpseudo_compat = no], [], [
+  AC_DEFINE([ENABLE_WRPSEUDO_COMPAT], 1, [Define if we should be compatible with pseudo])])
+
+dnl end LIBGLNX_CONFIGURE
+])

--- a/subprojects/libglnx/meson.build
+++ b/subprojects/libglnx/meson.build
@@ -1,0 +1,113 @@
+# Copyright 2019 Endless OS Foundation LLC
+# Copyright 2019 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+project(
+  'libglnx',
+  'c',
+  default_options : [
+    'c_std=gnu99',
+    'warning_level=2',
+  ],
+)
+
+add_project_arguments('-D_GNU_SOURCE', language: 'c')
+add_project_arguments('-Wno-unused-local-typedefs', language: 'c')
+
+# We are intentionally using non-ISO features in this (sub)project,
+# even if a parent project wants to use pedantic warnings
+add_project_arguments('-Wno-pedantic', language: 'c')
+add_project_arguments('-Wno-variadic-macros', language: 'c')
+
+cc = meson.get_compiler('c')
+
+
+check_functions = [
+  'renameat2',
+  'memfd_create',
+  'copy_file_range',
+]
+conf = configuration_data()
+foreach check_function : check_functions
+  have_it = cc.compiles('''
+    #include <sys/types.h>
+    #include <unistd.h>
+    #include <stdio.h>
+    #include <sys/mount.h>
+    #include <fcntl.h>
+    #include <sched.h>
+    #include <linux/loop.h>
+    #include <linux/random.h>
+    #include <sys/mman.h>
+
+    int func (void) {
+      (void) ''' + check_function + ''';
+    }
+    ''',
+    args : '-D_GNU_SOURCE',
+    name : check_function + '() is declared',
+  )
+  conf.set10('HAVE_DECL_' + check_function.underscorify().to_upper(), have_it)
+endforeach
+
+check_functions = [
+  'close_range',
+]
+foreach check_function : check_functions
+  if cc.has_function(check_function)
+    conf.set('HAVE_' + check_function.underscorify().to_upper(), 1)
+  endif
+endforeach
+
+config_h = configure_file(
+  output : 'libglnx-config.h',
+  configuration : conf,
+)
+
+libglnx_deps = [
+  dependency('gio-2.0'),
+  dependency('gio-unix-2.0'),
+]
+libglnx_inc = include_directories('.')
+libglnx_sources = [
+  'glnx-backport-autocleanups.h',
+  'glnx-backport-autoptr.h',
+  'glnx-backport-testutils.c',
+  'glnx-backport-testutils.h',
+  'glnx-backports.c',
+  'glnx-backports.h',
+  'glnx-console.c',
+  'glnx-console.h',
+  'glnx-dirfd.c',
+  'glnx-dirfd.h',
+  'glnx-errors.c',
+  'glnx-errors.h',
+  'glnx-fdio.c',
+  'glnx-fdio.h',
+  'glnx-local-alloc.c',
+  'glnx-local-alloc.h',
+  'glnx-lockfile.c',
+  'glnx-lockfile.h',
+  'glnx-macros.h',
+  'glnx-missing.h',
+  'glnx-missing-syscall.h',
+  'glnx-shutil.c',
+  'glnx-shutil.h',
+  'glnx-xattrs.c',
+  'glnx-xattrs.h',
+  'libglnx.h',
+]
+
+libglnx = static_library('glnx',
+  libglnx_sources,
+  dependencies : libglnx_deps,
+  gnu_symbol_visibility : 'hidden',
+  include_directories : libglnx_inc,
+  install : false)
+libglnx_dep = declare_dependency(
+  dependencies : libglnx_deps,
+  include_directories : libglnx_inc,
+  link_with : libglnx)
+
+subdir('tests')
+

--- a/subprojects/libglnx/meson.build
+++ b/subprojects/libglnx/meson.build
@@ -40,7 +40,7 @@ foreach check_function : check_functions
     #include <linux/random.h>
     #include <sys/mman.h>
 
-    int func (void) {
+    void func (void) {
       (void) ''' + check_function + ''';
     }
     ''',

--- a/subprojects/libglnx/meson_options.txt
+++ b/subprojects/libglnx/meson_options.txt
@@ -1,0 +1,9 @@
+# Copyright 2022 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+option(
+  'tests',
+  type : 'boolean',
+  description : 'build and run unit tests',
+  value : 'true',
+)

--- a/subprojects/libglnx/tests/libglnx-testlib.c
+++ b/subprojects/libglnx/tests/libglnx-testlib.c
@@ -1,0 +1,74 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright 2019 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx-testlib.h"
+
+#include <errno.h>
+
+#include <glib/gstdio.h>
+
+#include "libglnx.h"
+
+struct _GLnxTestAutoTempDir
+{
+  gchar *old_cwd;
+  int old_cwd_fd;
+  GLnxTmpDir temp_dir;
+};
+
+_GLnxTestAutoTempDir *
+_glnx_test_auto_temp_dir_enter (void)
+{
+  GError *error = NULL;
+  _GLnxTestAutoTempDir *ret = g_new0 (_GLnxTestAutoTempDir, 1);
+
+  glnx_mkdtemp ("glnx-test-XXXXXX", 0700, &ret->temp_dir, &error);
+  g_assert_no_error (error);
+
+  /* just for better diagnostics */
+  ret->old_cwd = g_get_current_dir ();
+
+  glnx_opendirat (-1, ".", TRUE, &ret->old_cwd_fd, &error);
+  g_assert_no_error (error);
+
+  if (fchdir (ret->temp_dir.fd) != 0)
+    g_error ("fchdir(<fd for \"%s\">): %s", ret->temp_dir.path, g_strerror (errno));
+
+  return ret;
+}
+
+void
+_glnx_test_auto_temp_dir_leave (_GLnxTestAutoTempDir *dir)
+{
+  GError *error = NULL;
+
+  if (fchdir (dir->old_cwd_fd) != 0)
+    g_error ("fchdir(<fd for \"%s\">): %s", dir->old_cwd, g_strerror (errno));
+
+  glnx_tmpdir_delete (&dir->temp_dir, NULL, &error);
+  g_assert_no_error (error);
+
+  glnx_close_fd (&dir->old_cwd_fd);
+
+  g_free (dir->old_cwd);
+  g_free (dir);
+}

--- a/subprojects/libglnx/tests/libglnx-testlib.h
+++ b/subprojects/libglnx/tests/libglnx-testlib.h
@@ -1,0 +1,49 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright 2019 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+#include "glnx-backport-autoptr.h"
+
+typedef GError _GLnxTestAutoError;
+static inline void
+_glnx_test_auto_error_cleanup (_GLnxTestAutoError *autoerror)
+{
+  g_assert_no_error (autoerror);
+  /* We could add a clear call here, but no point...we'll have aborted */
+}
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_GLnxTestAutoError, _glnx_test_auto_error_cleanup);
+
+#define _GLNX_TEST_DECLARE_ERROR(local_error, error)      \
+  g_autoptr(_GLnxTestAutoError) local_error = NULL; \
+  GError **error = &local_error
+
+typedef struct _GLnxTestAutoTempDir _GLnxTestAutoTempDir;
+
+_GLnxTestAutoTempDir *_glnx_test_auto_temp_dir_enter (void);
+void _glnx_test_auto_temp_dir_leave (_GLnxTestAutoTempDir *dir);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(_GLnxTestAutoTempDir, _glnx_test_auto_temp_dir_leave);
+
+#define _GLNX_TEST_SCOPED_TEMP_DIR \
+  G_GNUC_UNUSED g_autoptr(_GLnxTestAutoTempDir) temp_dir = _glnx_test_auto_temp_dir_enter ()

--- a/subprojects/libglnx/tests/meson.build
+++ b/subprojects/libglnx/tests/meson.build
@@ -1,0 +1,58 @@
+# Copyright 2019 Endless OS Foundation LLC
+# Copyright 2019 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+libglnx_testlib = static_library(
+  'glnx-testlib',
+  'libglnx-testlib.c',
+  'libglnx-testlib.h',
+  dependencies : [
+    libglnx_dep,
+    libglnx_deps,
+  ],
+  install : false,
+)
+libglnx_testlib_dep = declare_dependency(
+  dependencies : [
+    libglnx_dep,
+    libglnx_deps,
+  ],
+  include_directories : include_directories('.'),
+  link_with : libglnx_testlib,
+)
+
+if get_option('tests')
+  testing_helper = executable(
+    'testing-helper',
+    'testing-helper.c',
+    dependencies : [
+      libglnx_dep,
+      libglnx_deps,
+    ],
+    install : false,
+  )
+
+  test_names = [
+    'backports',
+    'errors',
+    'fdio',
+    'macros',
+    'shutil',
+    'testing',
+    'xattrs',
+  ]
+
+  foreach test_name : test_names
+    exe = executable(test_name,
+      [
+        'test-libglnx-' + test_name + '.c',
+      ],
+      dependencies: [
+        libglnx_dep,
+        libglnx_deps,
+        libglnx_testlib_dep,
+      ],
+    )
+    test(test_name, exe, depends: testing_helper)
+  endforeach
+endif

--- a/subprojects/libglnx/tests/test-libglnx-backports.c
+++ b/subprojects/libglnx/tests/test-libglnx-backports.c
@@ -1,0 +1,299 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 1995-1997  Peter Mattis, Spencer Kimball and Josh MacDonald
+ * Copyright (C) 2011 Red Hat, Inc.
+ * Copyright (C) 2018 Endless OS Foundation, LLC
+ * Copyright 2019 Emmanuel Fleury
+ * Copyright 2021-2024 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.1-or-later AND LicenseRef-old-glib-tests
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+
+#include <glib/gstdio.h>
+#include <glib-unix.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void
+async_signal_safe_message (const char *message)
+{
+  if (write (2, message, strlen (message)) < 0 ||
+      write (2, "\n", 1) < 0)
+    {
+      /* ignore: not much we can do */
+    }
+}
+
+static void test_closefrom_subprocess_einval (void);
+
+static void
+test_closefrom (void)
+{
+  /* Enough file descriptors to be confident that we're operating on
+   * all of them */
+  const int N_FDS = 20;
+  int *fds;
+  int fd;
+  int i;
+  pid_t child;
+  int wait_status;
+
+  /* The loop that populates @fds with pipes assumes this */
+  g_assert (N_FDS % 2 == 0);
+
+  for (fd = 0; fd <= 2; fd++)
+    {
+      int flags;
+
+      g_assert_no_errno ((flags = fcntl (fd, F_GETFD)));
+      g_assert_no_errno (fcntl (fd, F_SETFD, flags & ~FD_CLOEXEC));
+    }
+
+  fds = g_new0 (int, N_FDS);
+
+  for (i = 0; i < N_FDS; i += 2)
+    {
+      GError *error = NULL;
+      int pipefd[2];
+      int res;
+
+      /* Intentionally neither O_CLOEXEC nor FD_CLOEXEC */
+      res = g_unix_open_pipe (pipefd, 0, &error);
+      g_assert (res);
+      g_assert_no_error (error);
+      g_clear_error (&error);
+      fds[i] = pipefd[0];
+      fds[i + 1] = pipefd[1];
+    }
+
+  child = fork ();
+
+  /* Child process exits with status = 100 + the first wrong fd,
+   * or 0 if all were correct */
+  if (child == 0)
+    {
+      for (i = 0; i < N_FDS; i++)
+        {
+          int flags = fcntl (fds[i], F_GETFD);
+
+          if (flags == -1)
+            {
+              async_signal_safe_message ("fd should not have been closed");
+              _exit (100 + fds[i]);
+            }
+
+          if (flags & FD_CLOEXEC)
+            {
+              async_signal_safe_message ("fd should not have been close-on-exec yet");
+              _exit (100 + fds[i]);
+            }
+        }
+
+      g_fdwalk_set_cloexec (3);
+
+      for (i = 0; i < N_FDS; i++)
+        {
+          int flags = fcntl (fds[i], F_GETFD);
+
+          if (flags == -1)
+            {
+              async_signal_safe_message ("fd should not have been closed");
+              _exit (100 + fds[i]);
+            }
+
+          if (!(flags & FD_CLOEXEC))
+            {
+              async_signal_safe_message ("fd should have been close-on-exec");
+              _exit (100 + fds[i]);
+            }
+        }
+
+      g_closefrom (3);
+
+      for (fd = 0; fd <= 2; fd++)
+        {
+          int flags = fcntl (fd, F_GETFD);
+
+          if (flags == -1)
+            {
+              async_signal_safe_message ("fd should not have been closed");
+              _exit (100 + fd);
+            }
+
+          if (flags & FD_CLOEXEC)
+            {
+              async_signal_safe_message ("fd should not have been close-on-exec");
+              _exit (100 + fd);
+            }
+        }
+
+      for (i = 0; i < N_FDS; i++)
+        {
+          if (fcntl (fds[i], F_GETFD) != -1 || errno != EBADF)
+            {
+              async_signal_safe_message ("fd should have been closed");
+              _exit (100 + fds[i]);
+            }
+        }
+
+      _exit (0);
+    }
+
+  g_assert_no_errno (waitpid (child, &wait_status, 0));
+
+  if (WIFEXITED (wait_status))
+    {
+      int exit_status = WEXITSTATUS (wait_status);
+
+      if (exit_status != 0)
+        g_test_fail_printf ("File descriptor %d in incorrect state", exit_status - 100);
+    }
+  else
+    {
+      g_test_fail_printf ("Unexpected wait status %d", wait_status);
+    }
+
+  for (i = 0; i < N_FDS; i++)
+    g_assert_no_errno (close (fds[i]));
+
+  g_free (fds);
+
+  if (g_test_undefined ())
+    {
+#if GLIB_CHECK_VERSION (2, 38, 0)
+      g_test_trap_subprocess ("/glib-unix/closefrom/subprocess/einval",
+                              0, G_TEST_SUBPROCESS_DEFAULT);
+#else
+      if (g_test_trap_fork (0, 0))
+        {
+          test_closefrom_subprocess_einval ();
+          exit (0);
+        }
+
+#endif
+      g_test_trap_assert_passed ();
+    }
+}
+
+static void
+test_closefrom_subprocess_einval (void)
+{
+  int res;
+  int errsv;
+
+  g_log_set_always_fatal (G_LOG_FATAL_MASK);
+  g_log_set_fatal_mask ("GLib", G_LOG_FATAL_MASK);
+
+  errno = 0;
+  res = g_closefrom (-1);
+  errsv = errno;
+  g_assert_cmpint (res, ==, -1);
+  g_assert_cmpint (errsv, ==, EINVAL);
+
+  errno = 0;
+  res = g_fdwalk_set_cloexec (-42);
+  errsv = errno;
+  g_assert_cmpint (res, ==, -1);
+  g_assert_cmpint (errsv, ==, EINVAL);
+}
+
+/* Testing g_memdup2() function with various positive and negative cases */
+static void
+test_memdup2 (void)
+{
+  gchar *str_dup = NULL;
+  const gchar *str = "The quick brown fox jumps over the lazy dog";
+
+  /* Testing negative cases */
+  g_assert_null (g_memdup2 (NULL, 1024));
+  g_assert_null (g_memdup2 (str, 0));
+  g_assert_null (g_memdup2 (NULL, 0));
+
+  /* Testing normal usage cases */
+  str_dup = g_memdup2 (str, strlen (str) + 1);
+  g_assert_nonnull (str_dup);
+  g_assert_cmpstr (str, ==, str_dup);
+
+  g_free (str_dup);
+}
+
+static void
+test_steal_fd (void)
+{
+  GError *error = NULL;
+  gchar *tmpfile = NULL;
+  int fd = -42;
+  int borrowed;
+  int stolen;
+
+  g_assert_cmpint (g_steal_fd (&fd), ==, -42);
+  g_assert_cmpint (fd, ==, -1);
+  g_assert_cmpint (g_steal_fd (&fd), ==, -1);
+  g_assert_cmpint (fd, ==, -1);
+
+  fd = g_file_open_tmp (NULL, &tmpfile, &error);
+  g_assert_cmpint (fd, >=, 0);
+  g_assert_no_error (error);
+  borrowed = fd;
+  stolen = g_steal_fd (&fd);
+  g_assert_cmpint (fd, ==, -1);
+  g_assert_cmpint (borrowed, ==, stolen);
+
+  g_assert_no_errno (close (g_steal_fd (&stolen)));
+  g_assert_cmpint (stolen, ==, -1);
+
+  g_assert_no_errno (remove (tmpfile));
+  g_free (tmpfile);
+
+  /* Backwards compatibility with older libglnx: glnx_steal_fd is the same
+   * as g_steal_fd */
+  fd = -23;
+  g_assert_cmpint (glnx_steal_fd (&fd), ==, -23);
+  g_assert_cmpint (fd, ==, -1);
+}
+
+/* Test g_strv_equal() works for various inputs. */
+static void
+test_strv_equal (void)
+{
+  const gchar *strv_empty[] = { NULL };
+  const gchar *strv_empty2[] = { NULL };
+  const gchar *strv_simple[] = { "hello", "you", NULL };
+  const gchar *strv_simple2[] = { "hello", "you", NULL };
+  const gchar *strv_simple_reordered[] = { "you", "hello", NULL };
+  const gchar *strv_simple_superset[] = { "hello", "you", "again", NULL };
+  const gchar *strv_another[] = { "not", "a", "coded", "message", NULL };
+
+  g_assert_true (g_strv_equal (strv_empty, strv_empty));
+  g_assert_true (g_strv_equal (strv_empty, strv_empty2));
+  g_assert_true (g_strv_equal (strv_empty2, strv_empty));
+  g_assert_false (g_strv_equal (strv_empty, strv_simple));
+  g_assert_false (g_strv_equal (strv_simple, strv_empty));
+  g_assert_true (g_strv_equal (strv_simple, strv_simple));
+  g_assert_true (g_strv_equal (strv_simple, strv_simple2));
+  g_assert_true (g_strv_equal (strv_simple2, strv_simple));
+  g_assert_false (g_strv_equal (strv_simple, strv_simple_reordered));
+  g_assert_false (g_strv_equal (strv_simple_reordered, strv_simple));
+  g_assert_false (g_strv_equal (strv_simple, strv_simple_superset));
+  g_assert_false (g_strv_equal (strv_simple_superset, strv_simple));
+  g_assert_false (g_strv_equal (strv_simple, strv_another));
+  g_assert_false (g_strv_equal (strv_another, strv_simple));
+}
+
+int main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/glib-unix/closefrom", test_closefrom);
+#if GLIB_CHECK_VERSION (2, 38, 0)
+  g_test_add_func ("/glib-unix/closefrom/subprocess/einval",
+                   test_closefrom_subprocess_einval);
+#endif
+  g_test_add_func ("/mainloop/steal-fd", test_steal_fd);
+  g_test_add_func ("/strfuncs/memdup2", test_memdup2);
+  g_test_add_func ("/strfuncs/strv-equal", test_strv_equal);
+  return g_test_run();
+}

--- a/subprojects/libglnx/tests/test-libglnx-errors.c
+++ b/subprojects/libglnx/tests/test-libglnx-errors.c
@@ -1,0 +1,184 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+static void
+test_error_throw (void)
+{
+  g_autoptr(GError) error = NULL;
+
+  g_assert (!glnx_throw (&error, "foo: %s %d", "hello", 42));
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
+  g_assert_cmpstr (error->message, ==, "foo: hello 42");
+  g_clear_error (&error);
+
+  gpointer dummy = glnx_null_throw (&error, "literal foo");
+  g_assert (dummy == NULL);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
+  g_assert_cmpstr (error->message, ==, "literal foo");
+  g_clear_error (&error);
+
+  gpointer dummy2 = glnx_null_throw (&error, "foo: %s %d", "hola", 24);
+  g_assert (dummy2 == NULL);
+  g_assert_error (error, G_IO_ERROR, G_IO_ERROR_FAILED);
+  g_assert_cmpstr (error->message, ==, "foo: hola 24");
+  g_clear_error (&error);
+}
+
+static void
+test_error_errno (void)
+{
+  g_autoptr(GError) error = NULL;
+  const char noent_path[] = "/enoent-this-should-not-exist";
+  int fd;
+
+  fd = open (noent_path, O_RDONLY);
+  if (fd < 0)
+    {
+      g_assert (!glnx_throw_errno (&error));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (!glnx_prefix_error (&error, "myprefix"));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, "myprefix: "));
+      g_clear_error (&error);
+    }
+  else
+    g_assert_cmpint (fd, ==, -1);
+
+  fd = open (noent_path, O_RDONLY);
+  if (fd < 0)
+    {
+      gpointer dummy = glnx_null_throw_errno (&error);
+      g_assert (dummy == NULL);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      dummy = glnx_prefix_error_null (&error, "myprefix");
+      g_assert (dummy == NULL);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, "myprefix: "));
+      g_clear_error (&error);
+    }
+  else
+    g_assert_cmpint (fd, ==, -1);
+
+  fd = open (noent_path, O_RDONLY);
+  if (fd < 0)
+    {
+      g_autofree char *expected_prefix = g_strdup_printf ("Failed to open %s", noent_path);
+      g_assert (!glnx_throw_errno_prefix (&error, "Failed to open %s", noent_path));
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, expected_prefix));
+      g_clear_error (&error);
+      /* And test the legacy wrapper */
+      glnx_set_prefix_error_from_errno (&error, "Failed to open %s", noent_path);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, expected_prefix));
+      g_clear_error (&error);
+    }
+  else
+    g_assert_cmpint (fd, ==, -1);
+
+  fd = open (noent_path, O_RDONLY);
+  if (fd < 0)
+    {
+      gpointer dummy = glnx_null_throw_errno_prefix (&error, "Failed to open file");
+      g_assert (dummy == NULL);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, "Failed to open file"));
+      g_clear_error (&error);
+    }
+  else
+    g_assert_cmpint (fd, ==, -1);
+
+  fd = open (noent_path, O_RDONLY);
+  if (fd < 0)
+    {
+      gpointer dummy = glnx_null_throw_errno_prefix (&error, "Failed to open %s", noent_path);
+      g_assert (dummy == NULL);
+      g_assert_error (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+      g_assert (g_str_has_prefix (error->message, glnx_strjoina ("Failed to open ", noent_path)));
+      g_clear_error (&error);
+    }
+  else
+    g_assert_cmpint (fd, ==, -1);
+}
+
+static void
+test_error_auto_nothrow (GError **error)
+{
+  GLNX_AUTO_PREFIX_ERROR("foo", error);
+  /* Side effect to avoid otherwise empty function */
+  g_assert_no_error (*error);
+}
+
+static void
+test_error_auto_throw (GError **error)
+{
+  GLNX_AUTO_PREFIX_ERROR("foo", error);
+  (void) glnx_throw (error, "oops");
+}
+
+static void
+test_error_auto_throw_recurse (GError **error)
+{
+  GLNX_AUTO_PREFIX_ERROR("foo", error);
+
+  if (TRUE)
+    {
+      GLNX_AUTO_PREFIX_ERROR("bar", error);
+      (void) glnx_throw (error, "oops");
+    }
+}
+
+static void
+test_error_auto (void)
+{
+  g_autoptr(GError) error = NULL;
+  test_error_auto_nothrow (&error);
+  g_assert_no_error (error);
+  test_error_auto_throw (&error);
+  g_assert_nonnull (error);
+  g_assert_cmpstr (error->message, ==, "foo: oops");
+  g_clear_error (&error);
+  test_error_auto_throw_recurse (&error);
+  g_assert_nonnull (error);
+  g_assert_cmpstr (error->message, ==, "foo: bar: oops");
+}
+
+int main (int argc, char **argv)
+{
+  int ret;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/error-throw", test_error_throw);
+  g_test_add_func ("/error-errno", test_error_errno);
+  g_test_add_func ("/error-auto", test_error_auto);
+
+  ret = g_test_run();
+
+  return ret;
+}

--- a/subprojects/libglnx/tests/test-libglnx-fdio.c
+++ b/subprojects/libglnx/tests/test-libglnx-fdio.c
@@ -1,0 +1,307 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <err.h>
+#include <string.h>
+
+#include "libglnx-testlib.h"
+
+static gboolean
+renameat_test_setup (int *out_srcfd, int *out_destfd,
+                     GError **error)
+{
+  glnx_autofd int srcfd = -1;
+  glnx_autofd int destfd = -1;
+
+  (void) glnx_shutil_rm_rf_at (AT_FDCWD, "srcdir", NULL, NULL);
+  if (mkdir ("srcdir", 0755) < 0)
+    err (1, "mkdir");
+  if (!glnx_opendirat (AT_FDCWD, "srcdir", TRUE, &srcfd, error))
+    return FALSE;
+  (void) glnx_shutil_rm_rf_at (AT_FDCWD, "destdir", NULL, NULL);
+  if (mkdir ("destdir", 0755) < 0)
+    err (1, "mkdir");
+  if (!glnx_opendirat (AT_FDCWD, "destdir", TRUE, &destfd, error))
+    return FALSE;
+
+  if (!glnx_file_replace_contents_at (srcfd, "foo", (guint8*)"foo contents", strlen ("foo contents"),
+                                      GLNX_FILE_REPLACE_NODATASYNC, NULL, error))
+    return FALSE;
+  if (!glnx_file_replace_contents_at (destfd, "bar", (guint8*)"bar contents", strlen ("bar contents"),
+                                      GLNX_FILE_REPLACE_NODATASYNC, NULL, error))
+    return FALSE;
+
+  *out_srcfd = srcfd; srcfd = -1;
+  *out_destfd = destfd; destfd = -1;
+  return TRUE;
+}
+
+static void
+test_renameat2_noreplace (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  glnx_autofd int srcfd = -1;
+  glnx_autofd int destfd = -1;
+  struct stat stbuf;
+
+  if (!renameat_test_setup (&srcfd, &destfd, error))
+    return;
+
+  if (glnx_renameat2_noreplace (srcfd, "foo", destfd, "bar") == 0)
+    g_assert_not_reached ();
+  else
+    {
+      g_assert_cmpint (errno, ==, EEXIST);
+    }
+
+  if (glnx_renameat2_noreplace (srcfd, "foo", destfd, "baz") < 0)
+    return (void)glnx_throw_errno_prefix (error, "renameat");
+  if (!glnx_fstatat (destfd, "bar", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+
+  if (fstatat (srcfd, "foo", &stbuf, AT_SYMLINK_NOFOLLOW) == 0)
+    g_assert_not_reached ();
+  else
+    g_assert_cmpint (errno, ==, ENOENT);
+}
+
+static void
+test_renameat2_exchange (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+
+  glnx_autofd int srcfd = -1;
+  glnx_autofd int destfd = -1;
+  if (!renameat_test_setup (&srcfd, &destfd, error))
+    return;
+
+  if (glnx_renameat2_exchange (AT_FDCWD, "srcdir", AT_FDCWD, "destdir") < 0)
+    return (void)glnx_throw_errno_prefix (error, "renameat");
+
+  /* Ensure the dir fds are the same */
+  struct stat stbuf;
+  if (!glnx_fstatat (srcfd, "foo", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  if (!glnx_fstatat (destfd, "bar", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  /* But the dirs should be swapped */
+  if (!glnx_fstatat (AT_FDCWD, "destdir/foo", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  if (!glnx_fstatat (AT_FDCWD, "srcdir/bar", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+}
+
+static void
+test_tmpfile (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+
+  g_auto(GLnxTmpfile) tmpf = { 0, };
+  if (!glnx_open_tmpfile_linkable_at (AT_FDCWD, ".", O_WRONLY|O_CLOEXEC, &tmpf, error))
+    return;
+  if (glnx_loop_write (tmpf.fd, "foo", strlen ("foo")) < 0)
+    return (void)glnx_throw_errno_prefix (error, "write");
+  if (glnx_link_tmpfile_at (&tmpf, GLNX_LINK_TMPFILE_NOREPLACE, AT_FDCWD, "foo", error))
+    return;
+}
+
+static void
+test_stdio_file (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  g_auto(GLnxTmpfile) tmpf = { 0, };
+  g_autoptr(FILE) f = NULL;
+
+  if (!glnx_open_anonymous_tmpfile (O_RDWR|O_CLOEXEC, &tmpf, error))
+    return;
+  f = fdopen (tmpf.fd, "w");
+  tmpf.fd = -1; /* Ownership was transferred via fdopen() */
+  if (!f)
+    return (void)glnx_throw_errno_prefix (error, "fdopen");
+  if (fwrite ("hello", 1, strlen ("hello"), f) != strlen ("hello"))
+    return (void)glnx_throw_errno_prefix (error, "fwrite");
+  if (!glnx_stdio_file_flush (f, error))
+    return;
+}
+
+static void
+test_fstatat (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  struct stat stbuf = { 0, };
+
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, ".", &stbuf, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, 0);
+  g_assert_no_error (local_error);
+  g_assert (S_ISDIR (stbuf.st_mode));
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, "nosuchfile", &stbuf, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, ENOENT);
+  g_assert_no_error (local_error);
+
+  /* test NULL parameter for stat */
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, ".", NULL, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, 0);
+  g_assert_no_error (local_error);
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, "nosuchfile", NULL, 0, error))
+    return;
+  g_assert_cmpint (errno, ==, ENOENT);
+  g_assert_no_error (local_error);
+}
+
+static void
+test_filecopy (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  const char foo[] = "foo";
+  struct stat stbuf;
+
+  if (!glnx_ensure_dir (AT_FDCWD, "subdir", 0755, error))
+    return;
+
+  if (!glnx_file_replace_contents_at (AT_FDCWD, foo, (guint8*)foo, sizeof (foo),
+                                      GLNX_FILE_REPLACE_NODATASYNC, NULL, error))
+    return;
+
+  /* Copy it into both the same dir and a subdir */
+  if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "bar",
+                          GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    return;
+  if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "subdir/bar",
+                          GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    return;
+  if (!glnx_fstatat (AT_FDCWD, "subdir/bar", &stbuf, 0, error))
+    return;
+
+  if (glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "bar",
+                         GLNX_FILE_COPY_NOXATTRS, NULL, error))
+    g_assert_not_reached ();
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_EXISTS);
+  g_clear_error (&local_error);
+
+  if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "bar",
+                          GLNX_FILE_COPY_NOXATTRS | GLNX_FILE_COPY_OVERWRITE,
+                          NULL, error))
+    return;
+
+  if (symlinkat ("nosuchtarget", AT_FDCWD, "link") < 0)
+    return (void) glnx_throw_errno_prefix (error, "symlinkat");
+
+  /* Shouldn't be able to overwrite a symlink without GLNX_FILE_COPY_OVERWRITE */
+  if (glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "link",
+                         GLNX_FILE_COPY_NOXATTRS,
+                         NULL, error))
+    g_assert_not_reached ();
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_EXISTS);
+  g_clear_error (&local_error);
+
+  /* Test overwriting symlink */
+  if (!glnx_file_copy_at (AT_FDCWD, foo, NULL, AT_FDCWD, "link",
+                          GLNX_FILE_COPY_NOXATTRS | GLNX_FILE_COPY_OVERWRITE,
+                          NULL, error))
+    return;
+
+  if (!glnx_fstatat_allow_noent (AT_FDCWD, "nosuchtarget", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  g_assert_cmpint (errno, ==, ENOENT);
+  g_assert_no_error (local_error);
+
+  if (!glnx_fstatat (AT_FDCWD, "link", &stbuf, AT_SYMLINK_NOFOLLOW, error))
+    return;
+  g_assert (S_ISREG (stbuf.st_mode));
+}
+
+static void
+test_filecopy_procfs (void)
+{
+  const char * const pseudo_files[] =
+  {
+    /* A file in /proc that stat()s as empty (at least on Linux 5.15) */
+    "/proc/version",
+    /* A file in /sys that stat()s as empty (at least on Linux 5.15) */
+    "/sys/fs/cgroup/cgroup.controllers",
+    /* A file in /sys that stat()s as non-empty (at least on Linux 5.15) */
+    "/sys/fs/ext4/features/meta_bg_resize",
+  };
+  gsize i;
+
+  for (i = 0; i < G_N_ELEMENTS (pseudo_files); i++)
+    {
+      _GLNX_TEST_DECLARE_ERROR(local_error, error);
+      g_autofree char *contents = NULL;
+      g_autofree char *contents_of_copy = NULL;
+      gsize len;
+      gsize len_copy;
+
+      if (!g_file_get_contents (pseudo_files[i], &contents, &len, error))
+        {
+          g_test_message ("Not testing %s: %s",
+                          pseudo_files[i], local_error->message);
+          g_clear_error (&local_error);
+          continue;
+        }
+
+      if (!glnx_file_copy_at (AT_FDCWD, pseudo_files[i], NULL,
+                              AT_FDCWD, "copy",
+                              (GLNX_FILE_COPY_OVERWRITE |
+                               GLNX_FILE_COPY_NOCHOWN |
+                               GLNX_FILE_COPY_NOXATTRS),
+                              NULL, error))
+        return;
+
+      g_assert_no_error (local_error);
+
+      if (!g_file_get_contents ("copy", &contents_of_copy, &len_copy, error))
+        return;
+
+      g_assert_no_error (local_error);
+
+      g_assert_cmpstr (contents, ==, contents_of_copy);
+      g_assert_cmpuint (len, ==, len_copy);
+    }
+}
+
+int main (int argc, char **argv)
+{
+  _GLNX_TEST_SCOPED_TEMP_DIR;
+  int ret;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/tmpfile", test_tmpfile);
+  g_test_add_func ("/stdio-file", test_stdio_file);
+  g_test_add_func ("/filecopy", test_filecopy);
+  g_test_add_func ("/filecopy-procfs", test_filecopy_procfs);
+  g_test_add_func ("/renameat2-noreplace", test_renameat2_noreplace);
+  g_test_add_func ("/renameat2-exchange", test_renameat2_exchange);
+  g_test_add_func ("/fstat", test_fstatat);
+
+  ret = g_test_run();
+
+  return ret;
+}

--- a/subprojects/libglnx/tests/test-libglnx-macros.c
+++ b/subprojects/libglnx/tests/test-libglnx-macros.c
@@ -1,0 +1,118 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+static void
+test_info (void)
+{
+  g_info ("hello, world");
+  g_info ("answer=%d", 42);
+}
+
+static void
+test_inset (void)
+{
+  g_assert (G_IN_SET (7, 7));
+  g_assert (G_IN_SET (7, 42, 7));
+  g_assert (G_IN_SET (7, 7,42,3,9));
+  g_assert (G_IN_SET (42, 7,42,3,9));
+  g_assert (G_IN_SET (3, 7,42,3,9));
+  g_assert (G_IN_SET (9, 7,42,3,9));
+  g_assert (!G_IN_SET (8, 7,42,3,9));
+  g_assert (!G_IN_SET (-1, 7,42,3,9));
+  g_assert (G_IN_SET ('x', 'a', 'x', 'c'));
+  g_assert (!G_IN_SET ('y', 'a', 'x', 'c'));
+}
+
+static void
+test_hash_table_foreach (void)
+{
+  /* use var names all different from the macro metavars to ensure proper
+   * substitution */
+  g_autoptr(GHashTable) table = g_hash_table_new (g_str_hash, g_str_equal);
+  const char *keys[] = {"key1", "key2"};
+  const char *vals[] = {"val1", "val2"};
+  g_hash_table_insert (table, (gpointer)keys[0], (gpointer)vals[0]);
+  g_hash_table_insert (table, (gpointer)keys[1], (gpointer)vals[1]);
+
+  guint i = 0;
+  GLNX_HASH_TABLE_FOREACH_IT (table, it, const char*, key, const char*, val)
+    {
+      g_assert_cmpstr (key, ==, keys[i]);
+      g_assert_cmpstr (val, ==, vals[i]);
+      i++;
+    }
+  g_assert_cmpuint (i, ==, 2);
+
+  i = 0;
+  GLNX_HASH_TABLE_FOREACH_IT (table, it, const char*, key, const char*, val)
+    {
+      g_hash_table_iter_remove (&it);
+      break;
+    }
+  g_assert_cmpuint (g_hash_table_size (table), ==, 1);
+
+  g_hash_table_insert (table, (gpointer)keys[1], (gpointer)vals[1]);
+  g_assert_cmpuint (g_hash_table_size (table), ==, 1);
+
+  g_hash_table_insert (table, (gpointer)keys[0], (gpointer)vals[0]);
+  g_assert_cmpuint (g_hash_table_size (table), ==, 2);
+
+  i = 0;
+  GLNX_HASH_TABLE_FOREACH_KV (table, const char*, key, const char*, val)
+    {
+      g_assert_cmpstr (key, ==, keys[i]);
+      g_assert_cmpstr (val, ==, vals[i]);
+      i++;
+    }
+  g_assert_cmpuint (i, ==, 2);
+
+  i = 0;
+  GLNX_HASH_TABLE_FOREACH (table, const char*, key)
+    {
+      g_assert_cmpstr (key, ==, keys[i]);
+      i++;
+    }
+  g_assert_cmpuint (i, ==, 2);
+
+  i = 0;
+  GLNX_HASH_TABLE_FOREACH_V (table, const char*, val)
+    {
+      g_assert_cmpstr (val, ==, vals[i]);
+      i++;
+    }
+  g_assert_cmpuint (i, ==, 2);
+}
+
+int main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/info", test_info);
+  g_test_add_func ("/inset", test_inset);
+  g_test_add_func ("/hash_table_foreach", test_hash_table_foreach);
+  return g_test_run();
+}

--- a/subprojects/libglnx/tests/test-libglnx-shutil.c
+++ b/subprojects/libglnx/tests/test-libglnx-shutil.c
@@ -1,0 +1,64 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright © 2017 Endless OS Foundation LLC
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <err.h>
+#include <string.h>
+
+#include "libglnx-testlib.h"
+
+static void
+test_mkdir_p_enoent (void)
+{
+  _GLNX_TEST_DECLARE_ERROR(local_error, error);
+  glnx_autofd int dfd = -1;
+
+  if (!glnx_ensure_dir (AT_FDCWD, "test", 0755, error))
+    return;
+  if (!glnx_opendirat (AT_FDCWD, "test", FALSE, &dfd, error))
+    return;
+  if (rmdir ("test") < 0)
+    return (void) glnx_throw_errno_prefix (error, "rmdir(%s)", "test");
+
+  /* This should fail with ENOENT. */
+  glnx_shutil_mkdir_p_at (dfd, "blah/baz", 0755, NULL, error);
+  g_assert_error (local_error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+  g_clear_error (&local_error);
+}
+
+int
+main (int    argc,
+      char **argv)
+{
+  int ret;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/mkdir-p/enoent", test_mkdir_p_enoent);
+
+  ret = g_test_run();
+
+  return ret;
+}

--- a/subprojects/libglnx/tests/test-libglnx-testing.c
+++ b/subprojects/libglnx/tests/test-libglnx-testing.c
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2022 Simon McVittie
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#if GLIB_CHECK_VERSION (2, 38, 0)
+#define GTEST_TAP_OR_VERBOSE "--tap"
+#else
+#define GTEST_TAP_OR_VERBOSE "--verbose"
+#endif
+
+static const char *null = NULL;
+static const char *nonnull = "not null";
+
+static void
+test_assertions (void)
+{
+  const char *other_nonnull = "not null";
+  g_autoptr(GVariant) va = g_variant_ref_sink (g_variant_new ("i", 42));
+  g_autoptr(GVariant) vb = g_variant_ref_sink (g_variant_new ("i", 42));
+  const char * const strv1[] = {"one", "two", NULL};
+  const char * const strv2[] = {"one", "two", NULL};
+  GStatBuf statbuf;
+
+  g_assert_true (null == NULL);
+  g_assert_false (null != NULL);
+  g_assert_null (null);
+  g_assert_nonnull (nonnull);
+  g_assert_cmpmem (null, 0, null, 0);
+  g_assert_cmpmem (nonnull, strlen (nonnull), other_nonnull, strlen (other_nonnull));
+  g_assert_cmpfloat_with_epsilon (1.0, 1.00001, 0.01);
+  g_assert_cmpvariant (va, vb);
+  g_assert_no_errno (g_stat ("/", &statbuf));
+  g_assert_cmpstrv (NULL, NULL);
+  g_assert_cmpstrv (&null, &null);
+  g_assert_cmpstrv (strv1, strv2);
+}
+
+static void
+test_assertion_failures (void)
+{
+  static const char * const assertion_failures[] =
+  {
+    "true",
+    "false",
+    "nonnull",
+    "null",
+    "mem_null_nonnull",
+    "mem_nonnull_null",
+    "mem_len",
+    "mem_cmp",
+    "cmpfloat_with_epsilon",
+    "cmpvariant",
+    "errno",
+    "cmpstrv_null_nonnull",
+    "cmpstrv_nonnull_null",
+    "cmpstrv_len",
+    "cmpstrv_cmp",
+  };
+  g_autoptr(GError) error = NULL;
+  g_autofree char *self = NULL;
+  g_autofree char *dir = NULL;
+  g_autofree char *exe = NULL;
+  gsize i;
+
+  self = glnx_readlinkat_malloc (-1, "/proc/self/exe", NULL, &error);
+  g_assert_no_error (error);
+
+  dir = g_path_get_dirname (self);
+  exe = g_build_filename (dir, "testing-helper", NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (assertion_failures); i++)
+    {
+      g_autofree char *out = NULL;
+      g_autofree char *err = NULL;
+      g_autofree char *name = g_strdup_printf ("/assertion-failure/%s", assertion_failures[i]);
+      int wait_status = -1;
+      const char *argv[] = { NULL, "assertion-failures", "-p", NULL, NULL, NULL };
+      char *line;
+      char *saveptr = NULL;
+
+      argv[0] = exe;
+      argv[3] = name;
+      argv[4] = GTEST_TAP_OR_VERBOSE;
+      g_test_message ("%s assertion-failures -p %s %s...", exe, name, GTEST_TAP_OR_VERBOSE);
+
+      g_spawn_sync (NULL,   /* cwd */
+                    (char **) argv,
+                    NULL,   /* envp */
+                    G_SPAWN_DEFAULT,
+                    NULL,   /* child setup */
+                    NULL,   /* user data */
+                    &out,
+                    &err,
+                    &wait_status,
+                    &error);
+      g_assert_no_error (error);
+
+      g_assert_nonnull (out);
+      g_assert_nonnull (err);
+
+      for (line = strtok_r (out, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stdout: %s", line);
+
+      saveptr = NULL;
+
+      for (line = strtok_r (err, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stderr: %s", line);
+
+      g_test_message ("wait status: 0x%x", wait_status);
+
+      /* It exited with a nonzero status that was not exit status 77 */
+      G_STATIC_ASSERT (WIFEXITED (0));
+      G_STATIC_ASSERT (WEXITSTATUS (0) == 0);
+      g_assert_cmphex (wait_status, !=, 0);
+      G_STATIC_ASSERT (WIFEXITED (77 << 8));
+      G_STATIC_ASSERT (WEXITSTATUS (77 << 8) == 77);
+      g_assert_cmphex (wait_status, !=, (77 << 8));
+    }
+}
+
+static void
+test_failures (void)
+{
+  static const char * const failures[] =
+  {
+    "fail",
+    "fail-printf",
+  };
+  g_autoptr(GError) error = NULL;
+  g_autofree char *self = NULL;
+  g_autofree char *dir = NULL;
+  g_autofree char *exe = NULL;
+  gsize i;
+
+  self = glnx_readlinkat_malloc (-1, "/proc/self/exe", NULL, &error);
+  g_assert_no_error (error);
+
+  dir = g_path_get_dirname (self);
+  exe = g_build_filename (dir, "testing-helper", NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (failures); i++)
+    {
+      g_autofree char *out = NULL;
+      g_autofree char *err = NULL;
+      int wait_status = -1;
+      const char *argv[] = { NULL, NULL, NULL, NULL };
+      char *line;
+      char *saveptr = NULL;
+
+      argv[0] = exe;
+      argv[1] = failures[i];
+      argv[2] = GTEST_TAP_OR_VERBOSE;
+      g_test_message ("%s %s %s...", exe, failures[i], GTEST_TAP_OR_VERBOSE);
+
+      g_spawn_sync (NULL,   /* cwd */
+                    (char **) argv,
+                    NULL,   /* envp */
+                    G_SPAWN_DEFAULT,
+                    NULL,   /* child setup */
+                    NULL,   /* user data */
+                    &out,
+                    &err,
+                    &wait_status,
+                    &error);
+      g_assert_no_error (error);
+
+      for (line = strtok_r (out, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stdout: %s", line);
+
+      saveptr = NULL;
+
+      for (line = strtok_r (err, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stderr: %s", line);
+
+      g_test_message ("wait status: 0x%x", wait_status);
+
+      G_STATIC_ASSERT (WIFEXITED (0));
+      G_STATIC_ASSERT (WEXITSTATUS (0) == 0);
+      G_STATIC_ASSERT (WIFEXITED (77 << 8));
+      G_STATIC_ASSERT (WEXITSTATUS (77 << 8) == 77);
+
+      g_assert_cmphex (wait_status, !=, 0);
+      g_assert_cmphex (wait_status, !=, (77 << 8));
+    }
+}
+
+static void
+test_skips (void)
+{
+  static const char * const skips[] =
+  {
+    "skip",
+    "skip-printf",
+    "incomplete",
+    "incomplete-printf",
+  };
+  g_autoptr(GError) error = NULL;
+  g_autofree char *self = NULL;
+  g_autofree char *dir = NULL;
+  g_autofree char *exe = NULL;
+  gsize i;
+
+  self = glnx_readlinkat_malloc (-1, "/proc/self/exe", NULL, &error);
+  g_assert_no_error (error);
+
+  dir = g_path_get_dirname (self);
+  exe = g_build_filename (dir, "testing-helper", NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (skips); i++)
+    {
+      g_autofree char *out = NULL;
+      g_autofree char *err = NULL;
+      int wait_status = -1;
+      const char *argv[] = { NULL, NULL, NULL, NULL };
+      char *line;
+      char *saveptr = NULL;
+
+      argv[0] = exe;
+      argv[1] = skips[i];
+      argv[2] = GTEST_TAP_OR_VERBOSE;
+      g_test_message ("%s %s %s...", exe, skips[i], GTEST_TAP_OR_VERBOSE);
+
+      g_spawn_sync (NULL,   /* cwd */
+                    (char **) argv,
+                    NULL,   /* envp */
+                    G_SPAWN_DEFAULT,
+                    NULL,   /* child setup */
+                    NULL,   /* user data */
+                    &out,
+                    &err,
+                    &wait_status,
+                    &error);
+      g_assert_no_error (error);
+
+      for (line = strtok_r (out, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stdout: %s", line);
+
+      saveptr = NULL;
+
+      for (line = strtok_r (err, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stderr: %s", line);
+
+      g_test_message ("wait status: 0x%x", wait_status);
+
+      G_STATIC_ASSERT (WIFEXITED (0));
+      G_STATIC_ASSERT (WEXITSTATUS (0) == 0);
+      G_STATIC_ASSERT (WIFEXITED (77 << 8));
+      G_STATIC_ASSERT (WEXITSTATUS (77 << 8) == 77);
+
+      /* Ideally the exit status is 77, but it might be 0 with older GLib */
+      if (wait_status != 0)
+        g_assert_cmphex (wait_status, ==, (77 << 8));
+    }
+}
+
+static void
+test_successes (void)
+{
+  static const char * const successes[] =
+  {
+    "messages",
+    "pass",
+    "summary",
+  };
+  g_autoptr(GError) error = NULL;
+  g_autofree char *self = NULL;
+  g_autofree char *dir = NULL;
+  g_autofree char *exe = NULL;
+  gsize i;
+
+  self = glnx_readlinkat_malloc (-1, "/proc/self/exe", NULL, &error);
+  g_assert_no_error (error);
+
+  dir = g_path_get_dirname (self);
+  exe = g_build_filename (dir, "testing-helper", NULL);
+
+  for (i = 0; i < G_N_ELEMENTS (successes); i++)
+    {
+      g_autofree char *out = NULL;
+      g_autofree char *err = NULL;
+      int wait_status = -1;
+      const char *argv[] = { NULL, NULL, NULL, NULL };
+      char *line;
+      char *saveptr = NULL;
+
+      argv[0] = exe;
+      argv[1] = successes[i];
+      argv[2] = GTEST_TAP_OR_VERBOSE;
+      g_test_message ("%s %s %s...", exe, successes[i], GTEST_TAP_OR_VERBOSE);
+
+      g_spawn_sync (NULL,   /* cwd */
+                    (char **) argv,
+                    NULL,   /* envp */
+                    G_SPAWN_DEFAULT,
+                    NULL,   /* child setup */
+                    NULL,   /* user data */
+                    &out,
+                    &err,
+                    &wait_status,
+                    &error);
+      g_assert_no_error (error);
+
+      for (line = strtok_r (out, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stdout: %s", line);
+
+      saveptr = NULL;
+
+      for (line = strtok_r (err, "\n", &saveptr);
+           line != NULL;
+           line = strtok_r (NULL, "\n", &saveptr))
+        g_test_message ("stderr: %s", line);
+
+      g_test_message ("wait status: 0x%x", wait_status);
+
+      G_STATIC_ASSERT (WIFEXITED (0));
+      G_STATIC_ASSERT (WEXITSTATUS (0) == 0);
+      g_assert_cmphex (wait_status, ==, 0);
+    }
+}
+
+int
+main (int argc, char **argv)
+{
+  g_test_init (&argc, &argv, NULL);
+  g_test_add_func ("/assertions", test_assertions);
+  g_test_add_func ("/assertion_failures", test_assertion_failures);
+  g_test_add_func ("/failures", test_failures);
+  g_test_add_func ("/skips", test_skips);
+  g_test_add_func ("/successes", test_successes);
+  return g_test_run();
+}

--- a/subprojects/libglnx/tests/test-libglnx-xattrs.c
+++ b/subprojects/libglnx/tests/test-libglnx-xattrs.c
@@ -1,0 +1,288 @@
+/* -*- mode: C; c-file-style: "gnu"; indent-tabs-mode: nil; -*-
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+#include <glib.h>
+#include <stdlib.h>
+#include <gio/gio.h>
+#include <string.h>
+
+#define XATTR_THREAD_RUN_TIME_USECS (5 * G_USEC_PER_SEC)
+
+struct XattrWorker {
+  int dfd;
+  gboolean is_writer;
+  guint n_attrs_read;
+};
+
+typedef enum {
+  WRITE_RUN_MUTATE,
+  WRITE_RUN_CREATE,
+} WriteType;
+
+static gboolean
+set_random_xattr_value (int fd, const char *name, GError **error)
+{
+  const guint8 randxattrbyte = g_random_int_range (0, 256);
+  const guint32 randxattrvalue_len = (g_random_int () % 256) + 1; /* Picked to be not too small or large */
+  g_autofree char *randxattrvalue = g_malloc (randxattrvalue_len);
+
+  memset (randxattrvalue, randxattrbyte, randxattrvalue_len);
+
+  if (fsetxattr (fd, name, randxattrvalue, randxattrvalue_len, 0) < 0)
+    {
+      glnx_set_error_from_errno (error);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+add_random_xattrs (int fd, GError **error)
+{
+  const guint nattrs = MIN (2, g_random_int () % 16);
+
+  for (guint i = 0; i < nattrs; i++)
+    {
+      guint32 randxattrname_v = g_random_int ();
+      g_autofree char *randxattrname = g_strdup_printf ("user.test%u", randxattrname_v);
+
+      if (!set_random_xattr_value (fd, randxattrname, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+do_write_run (GLnxDirFdIterator *dfd_iter, GError **error)
+{
+  WriteType wtype = g_random_int () % 2;
+
+  if (wtype == WRITE_RUN_CREATE)
+    {
+      guint32 randname_v = g_random_int ();
+      g_autofree char *randname = g_strdup_printf ("file%u", randname_v);
+      glnx_autofd int fd = -1;
+
+    again:
+      fd = openat (dfd_iter->fd, randname, O_CREAT | O_EXCL, 0644);
+      if (fd < 0)
+        {
+          if (errno == EEXIST)
+            {
+              g_printerr ("Congratulations!  I suggest purchasing a lottery ticket today!\n");
+              goto again;
+            }
+          else
+            {
+              glnx_set_error_from_errno (error);
+              return FALSE;
+            }
+        }
+
+      if (!add_random_xattrs (fd, error))
+        return FALSE;
+      }
+  else if (wtype == WRITE_RUN_MUTATE)
+    {
+      while (TRUE)
+        {
+          struct dirent *dent;
+          if (!glnx_dirfd_iterator_next_dent (dfd_iter, &dent, NULL, error))
+            return FALSE;
+          if (!dent)
+            break;
+
+          glnx_autofd int fd = -1;
+          if (!glnx_openat_rdonly (dfd_iter->fd, dent->d_name, FALSE, &fd, error))
+            return FALSE;
+
+          g_autoptr(GVariant) current_xattrs = NULL;
+          if (!glnx_fd_get_all_xattrs (fd, &current_xattrs, NULL, error))
+            return FALSE;
+
+          for (size_t i = 0; i < g_variant_n_children (current_xattrs); i++)
+            {
+              const char *name, *value;
+              g_variant_get_child (current_xattrs, i, "(^&ay^&ay)", &name, &value);
+
+              /* We don't want to potentially test/change xattrs like security.selinux
+               * that were injected by the system.
+               */
+              if (!g_str_has_prefix (name, "user.test"))
+                continue;
+
+              if (!set_random_xattr_value (fd, name, error))
+                return FALSE;
+            }
+        }
+    }
+  else
+    g_assert_not_reached ();
+
+  return TRUE;
+}
+
+static gboolean
+do_read_run (GLnxDirFdIterator *dfd_iter,
+             guint *out_n_read,
+             GError **error)
+{
+  guint nattrs = 0;
+  while (TRUE)
+    {
+      struct dirent *dent;
+      if (!glnx_dirfd_iterator_next_dent (dfd_iter, &dent, NULL, error))
+        return FALSE;
+      if (!dent)
+        break;
+
+      glnx_autofd int fd = -1;
+      if (!glnx_openat_rdonly (dfd_iter->fd, dent->d_name, FALSE, &fd, error))
+        return FALSE;
+
+      g_autoptr(GVariant) current_xattrs = NULL;
+      if (!glnx_fd_get_all_xattrs (fd, &current_xattrs, NULL, error))
+        return FALSE;
+
+      /* We don't actually care about the values, just use the variable
+       * to avoid compiler warnings.
+       */
+      nattrs += g_variant_n_children (current_xattrs);
+    }
+
+  *out_n_read = nattrs;
+  return TRUE;
+}
+
+static gpointer
+xattr_thread (gpointer data)
+{
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+  struct XattrWorker *worker = data;
+  gint64 end_time = g_get_monotonic_time () + XATTR_THREAD_RUN_TIME_USECS;
+  guint n_read = 0;
+
+  while (g_get_monotonic_time () < end_time)
+    {
+      g_auto(GLnxDirFdIterator) dfd_iter = { 0, };
+
+      if (!glnx_dirfd_iterator_init_at (worker->dfd, ".", TRUE, &dfd_iter, error))
+        goto out;
+
+      if (worker->is_writer)
+        {
+          if (!do_write_run (&dfd_iter, error))
+            goto out;
+        }
+      else
+        {
+          if (!do_read_run (&dfd_iter, &n_read, error))
+            goto out;
+        }
+    }
+
+ out:
+  g_assert_no_error (local_error);
+
+  return GINT_TO_POINTER (n_read);
+}
+
+static void
+test_xattr_races (void)
+{
+  /* If for some reason we're built in a VM which only has one vcpu, let's still
+   * at least make the test do something.
+   */
+  /* FIXME - this deadlocks for me on 4.9.4-201.fc25.x86_64, whether
+   * using overlayfs or xfs as source/dest.
+   */
+#if GLIB_CHECK_VERSION (2, 36, 0)
+  const guint nprocs = MAX (4, g_get_num_processors ());
+#else
+  const guint nprocs = 4;
+#endif
+  struct XattrWorker wdata[nprocs];
+  GThread *threads[nprocs];
+  g_autoptr(GError) local_error = NULL;
+  GError **error = &local_error;
+  g_auto(GLnxTmpDir) tmpdir = { 0, };
+  g_autofree char *tmpdir_path = g_strdup_printf ("%s/libglnx-xattrs-XXXXXX",
+                                                  getenv ("TMPDIR") ?: "/var/tmp");
+  guint nread = 0;
+
+  if (!glnx_mkdtempat (AT_FDCWD, tmpdir_path, 0700,
+                       &tmpdir, error))
+    goto out;
+
+  /* Support people building/testing on tmpfs https://github.com/flatpak/flatpak/issues/686 */
+  if (fsetxattr (tmpdir.fd, "user.test", "novalue", strlen ("novalue"), 0) < 0)
+    {
+      if (errno == EOPNOTSUPP)
+        {
+          g_test_skip ("no xattr support");
+          return;
+        }
+      else
+        {
+          glnx_set_error_from_errno (error);
+          goto out;
+        }
+    }
+
+  for (guint i = 0; i < nprocs; i++)
+    {
+      struct XattrWorker *worker = &wdata[i];
+      worker->dfd = tmpdir.fd;
+      worker->is_writer = i % 2 == 0;
+      threads[i] = g_thread_new (NULL, xattr_thread, worker);
+    }
+
+  for (guint i = 0; i < nprocs; i++)
+    {
+      if (wdata[i].is_writer)
+        (void) g_thread_join (threads[i]);
+      else
+        nread += GPOINTER_TO_UINT (g_thread_join (threads[i]));
+    }
+
+  g_print ("Read %u xattrs race free!\n", nread);
+
+ out:
+  g_assert_no_error (local_error);
+}
+
+int main (int argc, char **argv)
+{
+  int ret;
+
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/xattr-races", test_xattr_races);
+
+  ret = g_test_run();
+
+  return ret;
+}

--- a/subprojects/libglnx/tests/testing-helper.c
+++ b/subprojects/libglnx/tests/testing-helper.c
@@ -1,0 +1,342 @@
+/*
+ * Based on glib/tests/testing-helper.c from GLib
+ *
+ * Copyright 2018-2022 Collabora Ltd.
+ * Copyright 2019 Руслан Ижбулатов
+ * Copyright 2018-2022 Endless OS Foundation LLC
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "libglnx-config.h"
+#include "libglnx.h"
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <locale.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+static const char *null = NULL;
+static const char *nonnull = "not null";
+
+static void
+test_pass (void)
+{
+}
+
+static void
+test_messages (void)
+{
+  g_test_message ("This message has multiple lines.\n"
+                  "In older GLib, it would corrupt TAP output.\n"
+                  "That's why libglnx provides a wrapper.\n");
+}
+
+static void
+test_assertion_failure_true (void)
+{
+  g_assert_true (null != NULL);
+}
+
+static void
+test_assertion_failure_false (void)
+{
+  g_assert_false (null == NULL);
+}
+
+static void
+test_assertion_failure_nonnull (void)
+{
+  g_assert_nonnull (null);
+}
+
+static void
+test_assertion_failure_null (void)
+{
+  g_assert_null (nonnull);
+}
+
+static void
+test_assertion_failure_mem_null_nonnull (void)
+{
+  g_assert_cmpmem (null, 0, nonnull, strlen (nonnull));
+}
+
+static void
+test_assertion_failure_mem_nonnull_null (void)
+{
+  g_assert_cmpmem (nonnull, strlen (nonnull), null, 0);
+}
+
+static void
+test_assertion_failure_mem_len (void)
+{
+  g_assert_cmpmem (nonnull, strlen (nonnull), nonnull, 0);
+}
+
+static void
+test_assertion_failure_mem_cmp (void)
+{
+  g_assert_cmpmem (nonnull, 4, nonnull + 4, 4);
+}
+
+static void
+test_assertion_failure_cmpfloat_with_epsilon (void)
+{
+  g_assert_cmpfloat_with_epsilon (1.0, 1.5, 0.001);
+}
+
+static void
+test_assertion_failure_cmpvariant (void)
+{
+  g_autoptr(GVariant) a = g_variant_ref_sink (g_variant_new ("i", 42));
+  g_autoptr(GVariant) b = g_variant_ref_sink (g_variant_new ("u", 42));
+
+  g_assert_cmpvariant (a, b);
+}
+
+static void
+test_assertion_failure_errno (void)
+{
+  g_assert_no_errno (mkdir ("/", 0755));
+}
+
+static void
+test_assertion_failure_cmpstrv_null_nonnull (void)
+{
+  const char * const b[] = { NULL };
+
+  g_assert_cmpstrv (NULL, b);
+}
+
+static void
+test_assertion_failure_cmpstrv_nonnull_null (void)
+{
+  const char * const a[] = { NULL };
+
+  g_assert_cmpstrv (a, NULL);
+}
+
+static void
+test_assertion_failure_cmpstrv_len (void)
+{
+  const char * const a[] = { "one", NULL };
+  const char * const b[] = { NULL };
+
+  g_assert_cmpstrv (a, b);
+}
+
+static void
+test_assertion_failure_cmpstrv_cmp (void)
+{
+  const char * const a[] = { "one", "two", NULL };
+  const char * const b[] = { "one", "three", NULL };
+
+  g_assert_cmpstrv (a, b);
+}
+
+static void
+test_skip (void)
+{
+  g_test_skip ("not enough tea");
+}
+
+static void
+test_skip_printf (void)
+{
+  const char *beverage = "coffee";
+
+  g_test_skip_printf ("not enough %s", beverage);
+}
+
+static void
+test_fail (void)
+{
+  g_test_fail ();
+}
+
+static void
+test_fail_printf (void)
+{
+  g_test_fail_printf ("this test intentionally left failing");
+}
+
+static void
+test_incomplete (void)
+{
+  g_test_incomplete ("mind reading not implemented yet");
+}
+
+static void
+test_incomplete_printf (void)
+{
+  const char *operation = "telekinesis";
+
+  g_test_incomplete_printf ("%s not implemented yet", operation);
+}
+
+static void
+test_summary (void)
+{
+  g_test_summary ("Tests that g_test_summary() works with TAP, by outputting a "
+                  "known summary message in testing-helper, and checking for "
+                  "it in the TAP output later.");
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  char *argv1;
+
+  setlocale (LC_ALL, "");
+
+#ifdef G_OS_WIN32
+  /* Windows opens std streams in text mode, with \r\n EOLs.
+   * Sometimes it's easier to force a switch to binary mode than
+   * to account for extra \r in testcases.
+   */
+  setmode (fileno (stdout), O_BINARY);
+#endif
+
+  g_return_val_if_fail (argc > 1, 1);
+  argv1 = argv[1];
+
+  if (argc > 2)
+    memmove (&argv[1], &argv[2], (argc - 2) * sizeof (char *));
+
+  argc -= 1;
+  argv[argc] = NULL;
+
+  if (g_strcmp0 (argv1, "init-null-argv0") == 0)
+    {
+      int test_argc = 0;
+      char *test_argva[1] = { NULL };
+      char **test_argv = test_argva;
+
+      /* Test that `g_test_init()` can handle being called with an empty argv
+       * and argc == 0. While this isn’t recommended, it is possible for another
+       * process to use execve() to call a gtest process this way, so we’d
+       * better handle it gracefully.
+       *
+       * This test can’t be run after `g_test_init()` has been called normally,
+       * as it isn’t allowed to be called more than once in a process. */
+      g_test_init (&test_argc, &test_argv, NULL);
+
+      return 0;
+    }
+
+  g_test_init (&argc, &argv, NULL);
+  g_test_disable_crash_reporting ();
+#if GLIB_CHECK_VERSION(2, 38, 0)
+  g_test_set_nonfatal_assertions ();
+#endif
+
+  if (g_strcmp0 (argv1, "pass") == 0)
+    {
+      g_test_add_func ("/pass", test_pass);
+    }
+  else if (g_strcmp0 (argv1, "messages") == 0)
+    {
+      g_test_add_func ("/messages", test_messages);
+    }
+  else if (g_strcmp0 (argv1, "skip") == 0)
+    {
+      g_test_add_func ("/skip", test_skip);
+    }
+  else if (g_strcmp0 (argv1, "skip-printf") == 0)
+    {
+      g_test_add_func ("/skip-printf", test_skip_printf);
+    }
+  else if (g_strcmp0 (argv1, "incomplete") == 0)
+    {
+      g_test_add_func ("/incomplete", test_incomplete);
+    }
+  else if (g_strcmp0 (argv1, "incomplete-printf") == 0)
+    {
+      g_test_add_func ("/incomplete-printf", test_incomplete_printf);
+    }
+  else if (g_strcmp0 (argv1, "fail") == 0)
+    {
+      g_test_add_func ("/fail", test_fail);
+    }
+  else if (g_strcmp0 (argv1, "fail-printf") == 0)
+    {
+      g_test_add_func ("/fail-printf", test_fail_printf);
+    }
+  else if (g_strcmp0 (argv1, "all-non-failures") == 0)
+    {
+      g_test_add_func ("/pass", test_pass);
+      g_test_add_func ("/skip", test_skip);
+      g_test_add_func ("/incomplete", test_incomplete);
+    }
+  else if (g_strcmp0 (argv1, "all") == 0)
+    {
+      g_test_add_func ("/pass", test_pass);
+      g_test_add_func ("/skip", test_skip);
+      g_test_add_func ("/incomplete", test_incomplete);
+      g_test_add_func ("/fail", test_fail);
+    }
+  else if (g_strcmp0 (argv1, "skip-options") == 0)
+    {
+      /* The caller is expected to skip some of these with
+       * -p/-r, -s/-x and/or --GTestSkipCount */
+      g_test_add_func ("/a", test_pass);
+      g_test_add_func ("/b", test_pass);
+      g_test_add_func ("/b/a", test_pass);
+      g_test_add_func ("/b/b", test_pass);
+      g_test_add_func ("/b/b/a", test_pass);
+      g_test_add_func ("/prefix/a", test_pass);
+      g_test_add_func ("/prefix/b/b", test_pass);
+      g_test_add_func ("/prefix-long/a", test_pass);
+      g_test_add_func ("/c/a", test_pass);
+      g_test_add_func ("/d/a", test_pass);
+    }
+  else if (g_strcmp0 (argv1, "summary") == 0)
+    {
+      g_test_add_func ("/summary", test_summary);
+    }
+  else if (g_strcmp0 (argv1, "assertion-failures") == 0)
+    {
+      /* Use -p to select a specific one of these */
+#define T(x) g_test_add_func ("/assertion-failure/" #x, test_assertion_failure_ ## x)
+      T (true);
+      T (false);
+      T (nonnull);
+      T (null);
+      T (mem_null_nonnull);
+      T (mem_nonnull_null);
+      T (mem_len);
+      T (mem_cmp);
+      T (cmpfloat_with_epsilon);
+      T (cmpvariant);
+      T (errno);
+      T (cmpstrv_null_nonnull);
+      T (cmpstrv_nonnull_null);
+      T (cmpstrv_len);
+      T (cmpstrv_cmp);
+#undef T
+    }
+  else
+    {
+      g_assert_not_reached ();
+    }
+
+  return g_test_run ();
+}

--- a/subprojects/libglnx/tests/use-as-subproject/.gitignore
+++ b/subprojects/libglnx/tests/use-as-subproject/.gitignore
@@ -1,0 +1,5 @@
+# Copyright 2022 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+/_build/
+/subprojects/

--- a/subprojects/libglnx/tests/use-as-subproject/README
+++ b/subprojects/libglnx/tests/use-as-subproject/README
@@ -1,0 +1,8 @@
+This is a simple example of a project that uses libglnx as a subproject.
+The intention is that if this project can successfully build and use libglnx
+as a subproject, then so could Flatpak.
+
+<!--
+Copyright 2022 Collabora Ltd.
+SPDX-License-Identifier: LGPL-2.0-or-later
+-->

--- a/subprojects/libglnx/tests/use-as-subproject/config.h
+++ b/subprojects/libglnx/tests/use-as-subproject/config.h
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#error Should not use superproject config.h to compile libglnx

--- a/subprojects/libglnx/tests/use-as-subproject/dummy-config.h.in
+++ b/subprojects/libglnx/tests/use-as-subproject/dummy-config.h.in
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#error Should not use superproject generated config.h to compile libglnx

--- a/subprojects/libglnx/tests/use-as-subproject/meson.build
+++ b/subprojects/libglnx/tests/use-as-subproject/meson.build
@@ -1,0 +1,48 @@
+# Copyright 2022 Collabora Ltd.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
+project(
+  'use-libglnx-as-subproject',
+  'c',
+  default_options : [
+    'c_std=gnu99',
+    'warning_level=3',
+  ],
+  version : '0',
+  meson_version : '>=0.49.0',
+)
+
+configure_file(
+  copy : true,
+  input : 'dummy-config.h.in',
+  output : 'config.h',
+)
+
+glib_dep = dependency('glib-2.0')
+
+libglnx = subproject('libglnx')
+libglnx_dep = libglnx.get_variable('libglnx_dep')
+libglnx_testlib_dep = libglnx.get_variable('libglnx_testlib_dep')
+
+# This executable is compiled at warning_level=3 by default
+executable(
+  'trivial',
+  'trivial.c',
+  dependencies : [glib_dep],
+)
+
+# These can't be compiled at warning_level=3 because they use non-ISO
+# compiler features in the libglnx headers, which would be warnings or
+# errors with -Wpedantic
+executable(
+  'use-libglnx',
+  'use-libglnx.c',
+  dependencies : [libglnx_dep, glib_dep],
+  override_options : ['warning_level=2'],
+)
+executable(
+  'use-testlib',
+  'use-testlib.c',
+  dependencies : [libglnx_testlib_dep, glib_dep],
+  override_options : ['warning_level=2'],
+)

--- a/subprojects/libglnx/tests/use-as-subproject/trivial.c
+++ b/subprojects/libglnx/tests/use-as-subproject/trivial.c
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include <glib.h>
+
+int
+main (void)
+{
+  GError *error = NULL;
+
+  g_clear_error (&error);
+  return 0;
+}

--- a/subprojects/libglnx/tests/use-as-subproject/use-libglnx.c
+++ b/subprojects/libglnx/tests/use-as-subproject/use-libglnx.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include <libglnx.h>
+
+int
+main (void)
+{
+  GError *error = NULL;
+
+  glnx_throw (&error, "whatever");
+  g_clear_error (&error);
+  return 0;
+}

--- a/subprojects/libglnx/tests/use-as-subproject/use-testlib.c
+++ b/subprojects/libglnx/tests/use-as-subproject/use-testlib.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Collabora Ltd.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
+#include <libglnx.h>
+#include <libglnx-testlib.h>
+
+int
+main (void)
+{
+  _GLNX_TEST_DECLARE_ERROR (local_error, error);
+
+  glnx_throw (error, "Whatever");
+  g_clear_error (&local_error);
+  return 0;
+}


### PR DESCRIPTION
  * Merge libglnx commit 'b38235ac2d8f1a7b1b8b9960a109eb734b8ec4dd'
    
      * Fix function detection when using -Werror=return-type
        (Resolves: flatpak/flatpak#5778)
      * Add a fallback definition for G_PID_FORMAT
      * Avoid warnings for g_steal_fd() when targeting older GLib
    
    This commit was created via:
    
        git remote add --no-tags libglnx https://gitlab.gnome.org/GNOME/libglnx.git
        git fetch libglnx
        git diff HEAD:subprojects/libglnx libglnx/master
        git subtree merge -P subprojects/libglnx libglnx/master
        git commit --amend -s

---

Normally this would be a pull request against `flatpak/flatpak` branch `main`, but I've generated this one against `smcv/flatpak` branch `libglnx-into-subtree` to illustrate what a subtree update would normally look like to reviewers.